### PR TITLE
feat: add pre-push hook to run full test suite

### DIFF
--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+
+echo "🔍 Running pre-push checks (same as CI)..."
+
+# Run formatting check
+echo "📝 Checking code formatting..."
+cargo fmt --check
+echo "✅ Formatting OK"
+
+# Run clippy
+echo "🔍 Running Clippy..."
+cargo clippy -- -D warnings
+echo "✅ Clippy OK"
+
+# Run unit tests
+echo "🧪 Running unit tests..."
+cargo test
+echo "✅ Unit tests OK"
+
+# Build the project
+echo "🔨 Building project..."
+cargo build --release
+echo "✅ Build OK"
+
+# Build anan-as if needed
+echo "🔧 Building anan-as..."
+cd vendor/anan-as
+if [ ! -d "node_modules" ]; then
+    npm ci
+fi
+npm run build
+cd ../..
+echo "✅ anan-as OK"
+
+# Build examples-as if needed
+echo "🔧 Building examples-as..."
+cd examples-as
+if [ ! -d "node_modules" ]; then
+    npm ci
+fi
+npm run build
+cd ..
+echo "✅ examples-as OK"
+
+# Run full integration test suite
+echo "🧪 Running full integration test suite (test-all.ts)..."
+npx tsx scripts/test-all.ts
+echo "✅ Integration tests OK"
+
+echo ""
+echo "🎉 All pre-push checks passed! You can now push safely."


### PR DESCRIPTION
## Summary

Adds a pre-push hook under version control that runs the full CI pipeline before allowing pushes.

## Changes

- Created `scripts/git-hooks/pre-push` - version-controlled pre-push hook
- Hook runs all CI checks:
  - `cargo fmt --check` - code formatting
  - `cargo clippy -- -D warnings` - linting
  - `cargo test` - Rust unit tests
  - `cargo build --release` - release build
  - `npm run build` for anan-as - PVM interpreter
  - `npm run build` for examples-as - AssemblyScript examples
  - `npx tsx scripts/test-all.ts` - full 62-test integration suite

## Setup

To install the hook locally:
```bash
cp scripts/git-hooks/pre-push .git/hooks/pre-push
chmod +x .git/hooks/pre-push
```

Or create a symlink for auto-updates:
```bash
ln -s ../../scripts/git-hooks/pre-push .git/hooks/pre-push
```

## Notes

- The hook uses `set -e` to fail fast on any check failure
- Dependencies are installed automatically if `node_modules` is missing
- Matches the exact sequence run in CI (`.github/workflows/ci.yml`)

---

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)
Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>