### PR TITLE
[#38] Fix memory.copy overlap tests for memmove semantics

### DIFF
--- a/crates/wasm-pvm/src/llvm_backend/memory.rs
+++ b/crates/wasm-pvm/src/llvm_backend/memory.rs
@@ -401,7 +401,11 @@ pub fn emit_pvm_memory_fill<'ctx>(
     Ok(())
 }
 
-/// Emit memory.copy operation (handles overlapping regions).
+/// Emit memory.copy with memmove semantics (handles overlapping regions).
+///
+/// When `dst > src`, a naive forward copy corrupts overlapping bytes before
+/// they are read. We detect this case and copy backward (from high to low
+/// addresses) so that source data is always read before being overwritten.
 pub fn emit_pvm_memory_copy<'ctx>(
     e: &mut PvmEmitter<'ctx>,
     instr: InstructionValue<'ctx>,

--- a/tests/fixtures/wat/memory-copy-overlap.jam.wat
+++ b/tests/fixtures/wat/memory-copy-overlap.jam.wat
@@ -1,20 +1,19 @@
 (module
   (memory 1)
-  
-  ;; Test memory.copy with overlapping regions
-  ;; This tests both forward and backward copy scenarios
-  
+
+  ;; Test memory.copy with overlapping regions (memmove semantics)
+  ;; Tests that overlapping copies preserve source data correctly.
+
   (func (export "main") (param $args_ptr i32) (param $args_len i32) (result i32 i32)
     (local $test_case i32)
     (local $result i32)
-    
-    ;; Load test case from args (0 = forward overlap, 1 = backward overlap)
+
+    ;; Load test case from args
     (local.set $test_case
       (i32.load (local.get $args_ptr))
     )
-    
+
     ;; Initialize memory with pattern: 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
-    ;; Using wasm-relative offsets (0x0-0x7) within the 64KiB memory
     (i32.store8 (i32.const 0x0) (i32.const 0x01))
     (i32.store8 (i32.const 0x1) (i32.const 0x02))
     (i32.store8 (i32.const 0x2) (i32.const 0x03))
@@ -23,48 +22,72 @@
     (i32.store8 (i32.const 0x5) (i32.const 0x06))
     (i32.store8 (i32.const 0x6) (i32.const 0x07))
     (i32.store8 (i32.const 0x7) (i32.const 0x08))
-    
+
     ;; Branch on test case
     (if (i32.eq (local.get $test_case) (i32.const 0))
       (then
-        ;; Test 0: Forward overlap
-        ;; Copy 4 bytes from 0x0 to 0x2
+        ;; Test 0: Overlapping copy, dst > src (requires backward copy / memmove)
+        ;; Copy 4 bytes from src=2 to dst=4
+        ;; src range: [2,5], dst range: [4,7], overlap at [4,5]
         ;; Before: [01 02 03 04 05 06 07 08]
-        ;; After:  [01 02 01 02 05 06 07 08]
+        ;; After:  [01 02 03 04 03 04 05 06]
+        ;; Without memmove (forward copy bug): [01 02 03 04 03 04 03 04]
         (memory.copy
-          (i32.const 0x2)  ;; dest (wasm-relative)
-          (i32.const 0x0)  ;; src (wasm-relative)
+          (i32.const 0x4)  ;; dest
+          (i32.const 0x2)  ;; src
           (i32.const 4)    ;; len
         )
-        
-        ;; Verify result: load 4 bytes from 0x0
-        ;; Expected: 0x02010201 (little-endian: 01 02 01 02)
+
+        ;; Read 4 bytes from addr 4 to verify the overlapping region
+        ;; Expected: [03 04 05 06] = 0x06050403 (little-endian)
         (local.set $result
-          (i32.load (i32.const 0x0))
+          (i32.load (i32.const 0x4))
         )
       )
       (else
-        ;; Test 1: Backward overlap
-        ;; Copy 4 bytes from 0x4 to 0x2
-        ;; Before: [01 02 03 04 05 06 07 08]
-        ;; After:  [01 02 05 06 07 08 07 08]
-        (memory.copy
-          (i32.const 0x2)  ;; dest (wasm-relative)
-          (i32.const 0x4)  ;; src (wasm-relative)
-          (i32.const 4)    ;; len
-        )
-        
-        ;; Verify result: load 4 bytes from 0x2
-        ;; Expected: 0x08070605 (little-endian: 05 06 07 08)
-        (local.set $result
-          (i32.load (i32.const 0x2))
+        (if (i32.eq (local.get $test_case) (i32.const 1))
+          (then
+            ;; Test 1: Overlapping copy, dst < src (forward copy is correct)
+            ;; Copy 4 bytes from src=4 to dst=2
+            ;; src range: [4,7], dst range: [2,5], overlap at [4,5]
+            ;; Before: [01 02 03 04 05 06 07 08]
+            ;; After:  [01 02 05 06 07 08 07 08]
+            (memory.copy
+              (i32.const 0x2)  ;; dest
+              (i32.const 0x4)  ;; src
+              (i32.const 4)    ;; len
+            )
+
+            ;; Read 4 bytes from addr 2
+            ;; Expected: [05 06 07 08] = 0x08070605 (little-endian)
+            (local.set $result
+              (i32.load (i32.const 0x2))
+            )
+          )
+          (else
+            ;; Test 2: Non-overlapping copy
+            ;; Copy 4 bytes from src=0 to dst=8
+            ;; Before: [01 02 03 04 05 06 07 08 00 00 00 00]
+            ;; After:  [01 02 03 04 05 06 07 08 01 02 03 04]
+            (memory.copy
+              (i32.const 0x8)  ;; dest
+              (i32.const 0x0)  ;; src
+              (i32.const 4)    ;; len
+            )
+
+            ;; Read 4 bytes from addr 8
+            ;; Expected: [01 02 03 04] = 0x04030201 (little-endian)
+            (local.set $result
+              (i32.load (i32.const 0x8))
+            )
+          )
         )
       )
     )
-    
+
     ;; Return result at wasm-relative address 0x100
     (i32.store (i32.const 0x100) (local.get $result))
-    
+
     ;; Return (ptr, len) - wasm-relative address
     (i32.const 0x100)
     (i32.const 4)

--- a/tests/layer2/memory-copy-overlap.test.ts
+++ b/tests/layer2/memory-copy-overlap.test.ts
@@ -1,8 +1,20 @@
 import { defineSuite } from "../helpers/suite";
 
 const tests = [
-  { args: "00000000", expected: 33620481, description: "memory.copy forward overlap: copy 4 bytes from 0x50000 to 0x50002" },
-  { args: "01000000", expected: 134678021, description: "memory.copy backward overlap: copy 4 bytes from 0x50004 to 0x50002" },
+  // Test 0: dst > src with overlap — requires backward copy (memmove).
+  // Copy 4 bytes from src=2 to dst=4. Read from addr 4.
+  // Correct: [03 04 05 06] = 0x06050403. Forward-copy bug: [03 04 03 04].
+  { args: "00000000", expected: 0x06050403, description: "memory.copy overlap dst>src (memmove backward)" },
+
+  // Test 1: dst < src with overlap — forward copy is correct.
+  // Copy 4 bytes from src=4 to dst=2. Read from addr 2.
+  // Correct: [05 06 07 08] = 0x08070605.
+  { args: "01000000", expected: 0x08070605, description: "memory.copy overlap dst<src (forward)" },
+
+  // Test 2: Non-overlapping copy.
+  // Copy 4 bytes from src=0 to dst=8. Read from addr 8.
+  // Correct: [01 02 03 04] = 0x04030201.
+  { args: "02000000", expected: 0x04030201, description: "memory.copy non-overlapping" },
 ];
 
 defineSuite({


### PR DESCRIPTION
## Summary

- The backward copy (memmove) implementation was already correct from PR #44, but the **tests were not actually verifying it** — test 0 read from an address that produces the same result whether or not the copy is correct.
- Rewrote tests so that test 0 (dst > src with overlap) reads from the overlapping destination region, where a forward-copy bug would produce `[03 04 03 04]` instead of the correct `[03 04 05 06]`.
- Added a non-overlapping copy test case.
- Improved the doc comment on `emit_pvm_memory_copy` explaining the memmove strategy.

## Test plan

- [x] All 368 integration tests pass (including 3 memory-copy-overlap tests)
- [x] All 56 Rust unit tests pass
- [x] `cargo clippy` clean
- [x] CodeRabbit local review — no issues

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)