### PR TITLE
Add callee-save shrink wrapping and configurable optimizations

### DIFF
--- a/crates/wasm-pvm/src/abi.rs
+++ b/crates/wasm-pvm/src/abi.rs
@@ -53,8 +53,9 @@ pub const MAX_LOCAL_REGS: usize = 4;
 
 // ── Stack Frame Layout ──
 
-/// Size of the standard stack frame header in bytes.
-/// Format:
+/// Maximum stack frame header size in bytes (used as default when shrink wrapping is disabled).
+///
+/// Layout (all callee-saved registers):
 /// - 0: Saved r0 (ra)
 /// - 8: Saved r9 (l0)
 /// - 16: Saved r10 (l1)
@@ -62,6 +63,10 @@ pub const MAX_LOCAL_REGS: usize = 4;
 /// - 32: Saved r12 (l3)
 ///
 /// Total: 5 * 8 = 40 bytes.
+///
+/// With shrink wrapping enabled, the actual header size is dynamic:
+/// `8 (ra) + 8 * num_used_callee_regs`. Only registers that are actually
+/// used by the function body are saved/restored.
 pub const FRAME_HEADER_SIZE: i32 = 40;
 
 /// Operand stack spill area base offset (relative to SP, negative direction).

--- a/crates/wasm-pvm/src/lib.rs
+++ b/crates/wasm-pvm/src/lib.rs
@@ -21,4 +21,6 @@ pub mod test_harness;
 pub use error::{Error, Result};
 pub use pvm::{Instruction, Opcode, ProgramBlob};
 pub use spi::SpiProgram;
-pub use translate::{CompileOptions, ImportAction, compile, compile_with_options};
+pub use translate::{
+    CompileOptions, ImportAction, OptimizationFlags, compile, compile_with_options,
+};

--- a/crates/wasm-pvm/src/llvm_backend/alu.rs
+++ b/crates/wasm-pvm/src/llvm_backend/alu.rs
@@ -308,7 +308,7 @@ pub fn lower_icmp<'ctx>(e: &mut PvmEmitter<'ctx>, instr: InstructionValue<'ctx>)
     // Optimization: if this ICmp is only used by a single branch instruction,
     // defer it for fusion — the branch will emit a single fused PVM branch
     // instead of computing a boolean and branching on it.
-    if is_single_use_by_branch(instr) {
+    if e.icmp_fusion_enabled && is_single_use_by_branch(instr) {
         e.pending_fused_icmp = Some(FusedIcmp {
             predicate: pred,
             lhs,

--- a/crates/wasm-pvm/src/llvm_backend/control_flow.rs
+++ b/crates/wasm-pvm/src/llvm_backend/control_flow.rs
@@ -264,13 +264,15 @@ fn emit_epilogue(e: &mut PvmEmitter<'_>, is_main: bool) {
             offset: 0,
         });
     } else {
-        // Restore callee-saved registers r9-r12.
+        // Restore callee-saved registers r9-r12 (only those actually saved).
         for i in 0..abi::MAX_LOCAL_REGS {
-            e.emit(Instruction::LoadIndU64 {
-                dst: abi::FIRST_LOCAL_REG + i as u8,
-                base: abi::STACK_PTR_REG,
-                offset: (8 + i * 8) as i32,
-            });
+            if let Some(offset) = e.callee_save_offsets[i] {
+                e.emit(Instruction::LoadIndU64 {
+                    dst: abi::FIRST_LOCAL_REG + i as u8,
+                    base: abi::STACK_PTR_REG,
+                    offset,
+                });
+            }
         }
 
         // Restore return address.

--- a/crates/wasm-pvm/src/llvm_frontend/function_builder.rs
+++ b/crates/wasm-pvm/src/llvm_frontend/function_builder.rs
@@ -239,7 +239,11 @@ impl<'ctx> WasmToLlvm<'ctx> {
         }
     }
 
-    pub fn translate_module(mut self, wasm_module: &WasmModule) -> Result<Module<'ctx>> {
+    pub fn translate_module(
+        mut self,
+        wasm_module: &WasmModule,
+        run_llvm_passes: bool,
+    ) -> Result<Module<'ctx>> {
         self.declare_functions(wasm_module);
         self.declare_globals(wasm_module);
         self.type_signatures
@@ -267,7 +271,9 @@ impl<'ctx> WasmToLlvm<'ctx> {
             )?;
         }
 
-        self.run_optimization_passes()?;
+        if run_llvm_passes {
+            self.run_optimization_passes()?;
+        }
 
         self.module
             .verify()

--- a/crates/wasm-pvm/src/llvm_frontend/mod.rs
+++ b/crates/wasm-pvm/src/llvm_frontend/mod.rs
@@ -13,11 +13,12 @@ use crate::translate::wasm_module::WasmModule;
 /// Translate a parsed WASM module into an LLVM IR module.
 ///
 /// Creates an LLVM context-scoped module with all functions and globals,
-/// then runs LLVM optimization passes (mem2reg, instcombine, simplifycfg, gvn, dce).
+/// then optionally runs LLVM optimization passes (mem2reg, instcombine, simplifycfg, gvn, dce).
 pub fn translate_wasm_to_llvm<'ctx>(
     context: &'ctx Context,
     wasm_module: &WasmModule,
+    run_llvm_passes: bool,
 ) -> Result<Module<'ctx>> {
     let translator = WasmToLlvm::new(context, "wasm_module");
-    translator.translate_module(wasm_module)
+    translator.translate_module(wasm_module, run_llvm_passes)
 }

--- a/crates/wasm-pvm/src/test_harness.rs
+++ b/crates/wasm-pvm/src/test_harness.rs
@@ -75,6 +75,12 @@ pub fn compile_wat_with_imports(
     )
 }
 
+/// Compile WAT with custom compile options
+pub fn compile_wat_with_options(wat: &str, options: &CompileOptions) -> Result<SpiProgram> {
+    let wasm = wat_to_wasm(wat)?;
+    compile_with_options(&wasm, options)
+}
+
 /// Extract the instruction sequence from a SPI program
 pub fn extract_instructions(program: &SpiProgram) -> Vec<Instruction> {
     program.code().instructions().to_vec()


### PR DESCRIPTION
## Summary

Closes #61.

- **Callee-save shrink wrapping**: Non-entry functions now only save/restore the callee-saved registers (r9-r12) they actually use, instead of unconditionally saving all 4. A register is "used" if it receives a parameter or the function contains any call instruction (conservative). Frame header size is dynamic: `8 (ra) + 8 * num_used_callee_regs`.
- **Configurable optimizations**: All non-trivial optimizations are now controllable via `OptimizationFlags` / CLI `--no-*` flags (all enabled by default): `--no-llvm-passes`, `--no-peephole`, `--no-register-cache`, `--no-icmp-fusion`, `--no-shrink-wrap`.
- **4 new unit tests** for shrink wrapping behavior (code size reduction, 0-param leaf, calling function, `--no-shrink-wrap` flag).
- **Documentation**: `AGENTS.md` updated with Optimization Flags reference table and threading guide for future agents.

## Benchmark comparison (main vs this PR)

The standard benchmark suite shows no change because these programs are dominated by entry functions and recursive functions (which save all callee-saved registers regardless):

| Benchmark | Size (before) | Size (after) | Size Δ | Gas (before) | Gas (after) | Gas Δ |
|-----------|--------------|-------------|--------|-------------|------------|-------|
| add(5,7) | 212 | 212 | +0 (0%) | 40 | 40 | +0 (0%) |
| fib(20) | 283 | 283 | +0 (0%) | 613 | 613 | +0 (0%) |
| factorial(10) | 259 | 259 | +0 (0%) | 280 | 280 | +0 (0%) |
| is_prime(25) | 415 | 415 | +0 (0%) | 100 | 100 | +0 (0%) |
| AS fib(10) | 845 | 845 | +0 (0%) | 348 | 348 | +0 (0%) |
| AS 7! | 838 | 838 | +0 (0%) | 310 | 310 | +0 (0%) |
| AS gcd(2017,200) | 838 | 838 | +0 (0%) | 220 | 220 | +0 (0%) |
| AS decoder | 139,503 | 139,503 | +0 (0%) | 2,213 | 2,213 | +0 (0%) |
| AS array | 138,541 | 138,541 | +0 (0%) | 1,829 | 1,829 | +0 (0%) |
| AS compiler (size) | 356,388 | 356,388 | +0 (0%) | - | - | - |

**Manual test with leaf helper functions** (`call.jam.wat`):
- With shrink wrapping: **249 bytes**
- Without (`--no-shrink-wrap`): **269 bytes**
- Savings: **20 bytes (7.4%)**

The optimization specifically benefits programs with leaf helper functions that use fewer than 4 parameters. For functions that make calls, the conservative analysis saves all registers (same as before).

## Test plan

- [x] `cargo test` — all 101 unit tests pass
- [x] Integration tests (Layer 1-3) — 372/372 pass
- [x] PVM-in-PVM tests (Layer 4-5) — 641/641 pass
- [x] `cargo clippy` — clean
- [x] Pre-push hook passes
- [x] Manual: `--no-shrink-wrap` flag produces expected larger output

🤖 Generated with [Claude Code](https://claude.com/claude-code)