### PR TITLE
Add immediate operand folding for ALU operations (#60)

### DIFF
--- a/crates/wasm-pvm/src/llvm_backend/emitter.rs
+++ b/crates/wasm-pvm/src/llvm_backend/emitter.rs
@@ -484,6 +484,16 @@ impl<'ctx> PvmEmitter<'ctx> {
     }
 }
 
+/// Try to extract a constant integer value from a `BasicValueEnum` without emitting instructions.
+/// Returns `Some(i64)` for compile-time constants, `None` for SSA values.
+pub fn try_get_constant(val: BasicValueEnum<'_>) -> Option<i64> {
+    if let BasicValueEnum::IntValue(iv) = val {
+        iv.get_sign_extended_constant()
+    } else {
+        None
+    }
+}
+
 /// Get the i-th operand of an instruction as a `BasicValueEnum`.
 pub fn get_operand(instr: InstructionValue<'_>, i: u32) -> Result<BasicValueEnum<'_>> {
     instr

--- a/crates/wasm-pvm/tests/harness_examples.rs
+++ b/crates/wasm-pvm/tests/harness_examples.rs
@@ -275,7 +275,8 @@ fn test_filter_by_opcode() {
     let program = compile_wat(wat).expect("Failed to compile");
     let instructions = extract_instructions(&program);
 
-    // Filter for all Add32 instructions
-    let adds = filter_by_opcode(&instructions, Opcode::Add32);
-    assert!(!adds.is_empty(), "Should have Add32 instructions");
+    // With immediate folding, `i32.const N; i32.add` becomes AddImm32,
+    // so we check for AddImm32 instructions instead of Add32.
+    let adds = filter_by_opcode(&instructions, Opcode::AddImm32);
+    assert!(!adds.is_empty(), "Should have AddImm32 instructions");
 }

--- a/crates/wasm-pvm/tests/import_returns.rs
+++ b/crates/wasm-pvm/tests/import_returns.rs
@@ -27,8 +27,9 @@ fn test_import_with_return_pushes_dummy_value() {
     let program = compile_wat_with_imports(wat, map).expect("Failed to compile");
     let instructions = extract_instructions(&program);
 
-    // Should have an Add32 instruction (proving we got past the import call)
-    assert!(has_opcode(&instructions, Opcode::Add32));
+    // Should have an AddImm32 instruction (proving we got past the import call).
+    // With immediate folding, `i32.const 1; i32.add` becomes AddImm32.
+    assert!(has_opcode(&instructions, Opcode::AddImm32));
 
     // The import stub should push a LoadImm 0 for the return value
     let load_zero = InstructionPattern::LoadImm {


### PR DESCRIPTION
## Summary
- Fold constant RHS operands into immediate PVM instructions, eliminating a `LoadImm` instruction per constant-operand operation
- **Add + constant RHS** → `AddImm32`/`AddImm64` (saves 1 instruction)
- **Sub + constant RHS** → `AddImm32`/`AddImm64` with negated value (saves 1 instruction, skips `i32::MIN`)
- **ICmp ULT + constant RHS** → `SetLtUImm` (saves 1 instruction)
- **ICmp SLT + constant RHS** → `SetLtSImm` (saves 1 instruction)

## Benchmark comparison

| Benchmark | Size (before) | Size (after) | Size Change | Gas (before) | Gas (after) | Gas Change |
|-----------|--------------|-------------|-------------|-------------|------------|------------|
| add(5,7) | 212 | 208 | -4 (-1.9%) | 40 | 39 | -1 (-2.5%) |
| fib(20) | 283 | 279 | -4 (-1.4%) | 613 | 593 | -20 (-3.3%) |
| factorial(10) | 259 | 256 | -3 (-1.2%) | 280 | 270 | -10 (-3.6%) |
| is_prime(25) | 415 | 411 | -4 (-1.0%) | 100 | 99 | -1 (-1.0%) |
| AS fib(10) | 845 | 832 | -13 (-1.5%) | 348 | 335 | -13 (-3.7%) |
| AS 7! | 838 | 824 | -14 (-1.7%) | 310 | 300 | -10 (-3.2%) |
| AS gcd(2017,200) | 838 | 825 | -13 (-1.6%) | 220 | 216 | -4 (-1.8%) |
| AS decoder | 139503 | 139295 | -208 (-0.1%) | 2213 | 2140 | -73 (-3.3%) |
| AS array | 138541 | 138347 | -194 (-0.1%) | 1829 | 1771 | -58 (-3.2%) |
| AS compiler (size) | 356388 | 352884 | -3504 (-1.0%) | - | - | - |

**Code size**: -0.1% to -1.9% across benchmarks (-3.5KB on anan-as compiler)
**Gas usage**: -1.0% to -3.7% across benchmarks

## Test plan
- [x] `cargo test` — all 96 Rust unit tests pass
- [x] `bun run test` — all 372 integration tests pass (layers 1-3)
- [x] PVM-in-PVM tests — all 273 tests pass (layers 4-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)