### PR TITLE
Add constant propagation during PVM lowering (#63)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,8 +203,9 @@ Each flag defaults to `true` (enabled). CLI exposes `--no-*` flags.
 | `icmp_branch_fusion` | `--no-icmp-fusion` | Fuse ICmp+Branch into single PVM branch | `llvm_backend/alu.rs:lower_icmp()` |
 | `shrink_wrap_callee_saves` | `--no-shrink-wrap` | Only save/restore used callee-saved regs | `llvm_backend/emitter.rs:pre_scan_function()` |
 | `dead_store_elimination` | `--no-dead-store-elim` | Remove SP-relative stores never loaded from | `llvm_backend/mod.rs:lower_function()` → `peephole.rs` |
+| `constant_propagation` | `--no-const-prop` | Skip redundant `LoadImm`/`LoadImm64` when register already holds the constant | `llvm_backend/emitter.rs:emit()` |
 
-**Threading path**: `CompileOptions.optimizations` → `LoweringContext.optimizations` → `PvmEmitter` fields (`register_cache_enabled`, `icmp_fusion_enabled`, `shrink_wrap_enabled`). LLVM passes flag is passed directly to `translate_wasm_to_llvm()`.
+**Threading path**: `CompileOptions.optimizations` → `LoweringContext.optimizations` → `PvmEmitter` fields (`register_cache_enabled`, `icmp_fusion_enabled`, `shrink_wrap_enabled`, `constant_propagation_enabled`). LLVM passes flag is passed directly to `translate_wasm_to_llvm()`.
 
 **Adding a new optimization**: Add a field to `OptimizationFlags`, thread it through `LoweringContext` → `PvmEmitter`, guard the optimization with the flag, add a `--no-*` CLI flag.
 

--- a/crates/wasm-pvm-cli/src/main.rs
+++ b/crates/wasm-pvm-cli/src/main.rs
@@ -56,6 +56,12 @@ enum Commands {
 
         #[arg(long, help = "Disable dead store elimination")]
         no_dead_store_elim: bool,
+
+        #[arg(
+            long,
+            help = "Disable constant propagation (redundant LoadImm elimination)"
+        )]
+        no_const_prop: bool,
     },
 }
 
@@ -78,6 +84,7 @@ fn main() -> Result<()> {
             no_icmp_fusion,
             no_shrink_wrap,
             no_dead_store_elim,
+            no_const_prop,
         } => {
             let wasm = read_wasm(&input)?;
 
@@ -112,6 +119,7 @@ fn main() -> Result<()> {
                     icmp_branch_fusion: !no_icmp_fusion,
                     shrink_wrap_callee_saves: !no_shrink_wrap,
                     dead_store_elimination: !no_dead_store_elim,
+                    constant_propagation: !no_const_prop,
                 },
             };
 

--- a/crates/wasm-pvm/src/llvm_backend/mod.rs
+++ b/crates/wasm-pvm/src/llvm_backend/mod.rs
@@ -56,6 +56,7 @@ pub fn lower_function(
     emitter.register_cache_enabled = ctx.optimizations.register_cache;
     emitter.icmp_fusion_enabled = ctx.optimizations.icmp_branch_fusion;
     emitter.shrink_wrap_enabled = ctx.optimizations.shrink_wrap_callee_saves;
+    emitter.constant_propagation_enabled = ctx.optimizations.constant_propagation;
 
     // Phase 1: Pre-scan — allocate labels for blocks and slots for all SSA values.
     pre_scan_function(&mut emitter, function, is_main);

--- a/crates/wasm-pvm/src/translate/mod.rs
+++ b/crates/wasm-pvm/src/translate/mod.rs
@@ -42,6 +42,8 @@ pub struct OptimizationFlags {
     pub shrink_wrap_callee_saves: bool,
     /// Eliminate SP-relative stores whose target offset is never loaded from.
     pub dead_store_elimination: bool,
+    /// Skip redundant `LoadImm`/`LoadImm64` when the register already holds the constant.
+    pub constant_propagation: bool,
 }
 
 impl Default for OptimizationFlags {
@@ -53,6 +55,7 @@ impl Default for OptimizationFlags {
             icmp_branch_fusion: true,
             shrink_wrap_callee_saves: true,
             dead_store_elimination: true,
+            constant_propagation: true,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Tracks which registers hold known constant values (`reg_to_const` array in `PvmEmitter`) and skips redundant `LoadImm`/`LoadImm64` when a register already contains the desired value
- Integrated into the `emit()` method so **all** `LoadImm` call sites across the codebase benefit automatically (30+ call sites in alu.rs, memory.rs, calls.rs, intrinsics.rs, control_flow.rs)
- Constant tracking is invalidated when a register is overwritten and cleared at block boundaries/calls (same semantics as the existing slot cache)
- Gated behind `--no-const-prop` CLI flag / `OptimizationFlags::constant_propagation` (enabled by default)

## Benchmark results

Consistent savings across all 60+ test binaries (5-52 bytes per program). Most impactful for complex programs with repeated constant patterns within basic blocks:

| Program | Size before | Size after | Saved |
|---------|------------|------------|-------|
| life.wasm | 2,426 | 2,374 | **52 bytes (2.1%)** |
| if-result-test | 1,537 | 1,522 | 15 bytes (1.0%) |
| u8-store-test | 3,360 | 3,349 | 11 bytes |
| alloc-test-incremental | 152,552 | 152,541 | 11 bytes |
| tests-arithmetic | 818 | 809 | 9 bytes (1.1%) |

No gas changes in the standard benchmark suite since the eliminated instructions only fire at compile time (fewer instructions in the binary, same execution paths).

## Test plan

- [x] All 372 integration tests pass (layers 1-3)
- [x] Layer 4 PVM-in-PVM smoke tests pass
- [x] All Rust unit tests pass (35+ tests)
- [x] Clippy and formatting pass
- [x] Verified optimization is correct: identical outputs for programs with no redundant constants
- [x] Verified `--no-const-prop` flag produces larger (pre-optimization) binaries

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)