### PR TITLE
Include top-level README in published crates

### DIFF
--- a/crates/wasm-pvm-cli/Cargo.toml
+++ b/crates/wasm-pvm-cli/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "../../README.md"
 
 [[bin]]
 name = "wasm-pvm"

--- a/crates/wasm-pvm/Cargo.toml
+++ b/crates/wasm-pvm/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "../../README.md"
 
 [features]
 default = ["test-harness"]


### PR DESCRIPTION
## Summary
- Add `readme = "../../README.md"` to both `wasm-pvm` and `wasm-pvm-cli` `Cargo.toml` so the top-level README is bundled with crates.io releases

## Test plan
- [x] `cargo package -p wasm-pvm --list | grep README` shows the README
- [x] `cargo package -p wasm-pvm-cli --list | grep README` shows the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)