### PR TITLE
Enable absolute address instructions for global/memory ops

### DIFF
--- a/crates/wasm-pvm/src/llvm_backend/memory.rs
+++ b/crates/wasm-pvm/src/llvm_backend/memory.rs
@@ -86,14 +86,9 @@ pub fn lower_wasm_global_store<'ctx>(
             }
 
             e.load_operand(val, TEMP1)?;
-            e.emit(Instruction::LoadImm {
-                reg: TEMP2,
-                value: global_addr,
-            });
-            e.emit(Instruction::StoreIndU32 {
-                base: TEMP2,
+            e.emit(Instruction::StoreU32 {
                 src: TEMP1,
-                offset: 0,
+                address: global_addr,
             });
             return Ok(());
         }
@@ -269,14 +264,9 @@ pub fn emit_pvm_memory_size<'ctx>(
     let slot = result_slot(e, instr)?;
     let global_addr = abi::memory_size_global_offset(ctx.num_globals);
 
-    e.emit(Instruction::LoadImm {
-        reg: TEMP1,
-        value: global_addr,
-    });
-    e.emit(Instruction::LoadIndU32 {
+    e.emit(Instruction::LoadU32 {
         dst: TEMP_RESULT,
-        base: TEMP1,
-        offset: 0,
+        address: global_addr,
     });
     e.store_to_slot(slot, TEMP_RESULT);
     Ok(())
@@ -298,14 +288,9 @@ pub fn emit_pvm_memory_grow<'ctx>(
     e.load_operand(delta, SCRATCH1)?;
 
     // Load current memory size into TEMP_RESULT (this will be the return value on success).
-    e.emit(Instruction::LoadImm {
-        reg: TEMP1,
-        value: global_addr,
-    });
-    e.emit(Instruction::LoadIndU32 {
+    e.emit(Instruction::LoadU32 {
         dst: TEMP_RESULT,
-        base: TEMP1,
-        offset: 0,
+        address: global_addr,
     });
 
     // new_size = current + delta
@@ -346,14 +331,9 @@ pub fn emit_pvm_memory_grow<'ctx>(
     });
 
     // Success: store new_size.
-    e.emit(Instruction::LoadImm {
-        reg: SCRATCH1,
-        value: global_addr,
-    });
-    e.emit(Instruction::StoreIndU32 {
-        base: SCRATCH1,
+    e.emit(Instruction::StoreU32 {
         src: SCRATCH2,
-        offset: 0,
+        address: global_addr,
     });
 
     // SBRK: grow PVM memory by (delta * 65536) bytes.
@@ -836,14 +816,9 @@ pub fn emit_pvm_memory_init<'ctx>(
     });
     // SCRATCH2 = memory_size (in pages)
     let mem_size_addr = crate::abi::memory_size_global_offset(ctx.num_globals);
-    e.emit(Instruction::LoadImm {
-        reg: SCRATCH2,
-        value: mem_size_addr,
-    });
-    e.emit(Instruction::LoadIndU32 {
+    e.emit(Instruction::LoadU32 {
         dst: SCRATCH2,
-        base: SCRATCH2,
-        offset: 0,
+        address: mem_size_addr,
     });
     // SCRATCH2 = memory_size * 65536 (shift left by 16)
     e.emit(Instruction::LoadImm {

--- a/crates/wasm-pvm/tests/operator_coverage.rs
+++ b/crates/wasm-pvm/tests/operator_coverage.rs
@@ -1996,7 +1996,7 @@ fn test_global_set_const_uses_store_imm() {
 
 /// global.set with a non-constant value should NOT use `StoreImm`.
 #[test]
-fn test_global_set_dynamic_uses_store_ind() {
+fn test_global_set_dynamic_uses_store_u32() {
     let wat = r#"
         (module
             (global $g (mut i32) (i32.const 0))
@@ -2010,10 +2010,10 @@ fn test_global_set_dynamic_uses_store_ind() {
     let program = compile_wat(wat).expect("compile");
     let instructions = extract_instructions(&program);
 
-    // Dynamic value should use LoadImm + StoreIndU32 (not StoreImmU32, which is for constants)
+    // Dynamic value should use StoreU32 (absolute address, not StoreImmU32 which is for constants)
     assert!(
-        has_opcode(&instructions, Opcode::StoreIndU32),
-        "global.set with dynamic value should use StoreIndU32.\nInstructions: {instructions:#?}"
+        has_opcode(&instructions, Opcode::StoreU32),
+        "global.set with dynamic value should use StoreU32.\nInstructions: {instructions:#?}"
     );
     assert!(
         !has_opcode(&instructions, Opcode::StoreImmU32),


### PR DESCRIPTION
## Summary

- Enables previously-deferred `StoreU32`/`LoadU32` absolute address instructions that were disabled due to PVM-in-PVM test failures
- These single-instruction patterns replace 2-instruction `LoadImm + LoadInd/StoreInd` sequences for global stores, memory_size, memory_grow, and memory.copy bounds checks
- All 273 PVM-in-PVM tests now pass with these optimizations enabled (the register allocator merged in #112 resolved the underlying layout sensitivity)

Closes #110

## Changes

- `llvm_backend/memory.rs`: Replace multi-instruction patterns with single absolute address instructions:
  - `lower_wasm_global_store` (non-constant): `LoadImm + StoreIndU32` -> `StoreU32`
  - `emit_pvm_memory_size`: `LoadImm + LoadIndU32` -> `LoadU32`
  - `emit_pvm_memory_grow` (load + store): `LoadImm + LoadIndU32/StoreIndU32` -> `LoadU32/StoreU32`
  - memory.copy bounds check: `LoadImm + LoadIndU32` -> `LoadU32`
- `tests/operator_coverage.rs`: Updated test to expect `StoreU32` instead of `StoreIndU32`

## Benchmarks

| Benchmark | Size (before) | Size (after) | Size Change | Gas (before) | Gas (after) | Gas Change |
|-----------|--------------|-------------|-------------|-------------|------------|------------|
| add(5,7)             |           66 |           66 |     +0 (+0.0%) |        208 |        208 |     +0 (+0.0%) |
| fib(20)              |          108 |          108 |     +0 (+0.0%) |        268 |        268 |     +0 (+0.0%) |
| factorial(10)        |          100 |          100 |     +0 (+0.0%) |        245 |        245 |     +0 (+0.0%) |
| is_prime(25)         |          160 |          160 |     +0 (+0.0%) |        327 |        327 |     +0 (+0.0%) |
| AS fib(10)           |          266 |          266 |     +0 (+0.0%) |        770 |        770 |     +0 (+0.0%) |
| AS factorial(7)      |          265 |          265 |     +0 (+0.0%) |        780 |        780 |     +0 (+0.0%) |
| AS gcd(2017,200)     |          260 |          260 |     +0 (+0.0%) |        754 |        754 |     +0 (+0.0%) |
| AS decoder           |         1564 |         1564 |     +0 (+0.0%) |      75191 |      75193 |     +2 (+0.0%) |
| AS array             |         1432 |         1432 |     +0 (+0.0%) |      74329 |      74326 |     -3 (-0.0%) |
| anan-as interpreter  |        59704 |        59704 |     +0 (+0.0%) |     246303 |     246357 |    +54 (+0.0%) |
| PiP TRAP             |            1 |            1 |     +0 (+0.0%) |      22921 |      22921 |     +0 (+0.0%) |
| PiP add(5,7)         |          208 |          208 |     +0 (+0.0%) |    1190025 |    1190025 |     +0 (+0.0%) |
| PiP AS fib(10)       |          770 |          770 |     +0 (+0.0%) |    1794589 |    1794589 |     +0 (+0.0%) |
| PiP JAM-SDK fib(10)  |        25965 |        25965 |     +0 (+0.0%) |    6863710 |    6863710 |     +0 (+0.0%) |
| PiP Jambrains fib(10)|        62591 |        62591 |     +0 (+0.0%) |    6728226 |    6728226 |     +0 (+0.0%) |
| PiP JADE fib(10)     |        68947 |        68947 |     +0 (+0.0%) |   18693440 |   18693440 |     +0 (+0.0%) |

Note: Minimal size/gas impact in benchmarks since these patterns only affect global store, memory_size, and memory_grow paths. The optimization saves 1 instruction per occurrence (removing LoadImm).

## Test plan

- [x] All Rust unit tests pass (including updated operator_coverage test)
- [x] All 412 integration tests pass
- [x] All 273 PVM-in-PVM tests pass (previously failing with these optimizations)
- [x] Clippy clean, formatting clean
- [x] Benchmarks show no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)