### PR TITLE
Replace hardcoded memory addresses with heap.alloc in AS test fixtures

### DIFF
--- a/tests/fixtures/assembly/tests-arrays.ts
+++ b/tests/fixtures/assembly/tests-arrays.ts
@@ -1,6 +1,6 @@
 // Memory addresses
 let RESULT_HEAP: usize = 0;
-const ARRAY_HEAP: u32 = 0x40000;
+let ARRAY_HEAP: usize = 0;
 
 // Globals
 export let result_ptr: i32 = 0;
@@ -34,6 +34,7 @@ function arraySum(arrPtr: i32): i32 {
 
 export function main(args_ptr: i32, args_len: i32): void {
   RESULT_HEAP = heap.alloc(256);
+  ARRAY_HEAP = heap.alloc(32); // length + 5 ints = 24 bytes
   const arr = ARRAY_HEAP;
   const len = 5;
   store<i32>(arr, len);

--- a/tests/fixtures/assembly/tests-linked-list.ts
+++ b/tests/fixtures/assembly/tests-linked-list.ts
@@ -1,6 +1,6 @@
 // Memory addresses
 let RESULT_HEAP: usize = 0;
-const NODE_HEAP: u32 = 0x40000;
+let NODE_HEAP: usize = 0;
 
 // Globals
 export let result_ptr: i32 = 0;
@@ -31,10 +31,8 @@ function sumList(head: i32): i32 {
 
 export function main(args_ptr: i32, args_len: i32): void {
   RESULT_HEAP = heap.alloc(256);
+  NODE_HEAP = heap.alloc(32); // 3 nodes * 8 bytes each = 24 bytes
   // Create list: 10 -> 20 -> 30 -> null
-  // Node 1 at 0x40000
-  // Node 2 at 0x40008
-  // Node 3 at 0x40010
 
   createNode(NODE_HEAP, 10, NODE_HEAP + 8);
   createNode(NODE_HEAP + 8, 20, NODE_HEAP + 16);

--- a/tests/fixtures/assembly/tests-memory.ts
+++ b/tests/fixtures/assembly/tests-memory.ts
@@ -1,6 +1,6 @@
 // Memory addresses
 let RESULT_HEAP: usize = 0;
-const DATA_HEAP: u32 = 0x40000; // Arbitrary safe location for data
+let DATA_HEAP: usize = 0;
 
 // Globals
 export let result_ptr: i32 = 0;
@@ -14,6 +14,7 @@ function writeResult(val: i32): void {
 
 export function main(args_ptr: i32, args_len: i32): void {
   RESULT_HEAP = heap.alloc(256);
+  DATA_HEAP = heap.alloc(16);
   // Store 8-bit values
   store<u8>(DATA_HEAP, 0xAA);
   store<u8>(DATA_HEAP + 1, 0xBB);

--- a/tests/fixtures/assembly/tests-structs.ts
+++ b/tests/fixtures/assembly/tests-structs.ts
@@ -1,6 +1,6 @@
 // Memory addresses
 let RESULT_HEAP: usize = 0;
-const STRUCT_HEAP: u32 = 0x40000;
+let STRUCT_HEAP: usize = 0;
 
 // Globals
 export let result_ptr: i32 = 0;
@@ -39,6 +39,7 @@ function dotProduct(ptr1: i32, ptr2: i32): i32 {
 
 export function main(args_ptr: i32, args_len: i32): void {
   RESULT_HEAP = heap.alloc(256);
+  STRUCT_HEAP = heap.alloc(32); // 2 structs * 12 bytes each
   const p1 = STRUCT_HEAP;
   const p2 = STRUCT_HEAP + 16;
 


### PR DESCRIPTION
## Summary
- Replaced hardcoded `0x40000` (256KB) memory addresses with dynamic `heap.alloc()` calls in 4 AS test fixtures (`tests-memory`, `tests-linked-list`, `tests-structs`, `tests-arrays`)
- This reduces unnecessary page allocations — the old code forced at least 5 WASM pages even though only a few bytes were needed
- All other test fixtures already used `heap.alloc()` correctly

## Test plan
- [x] All 412 layer1/layer2/layer3 tests pass
- [x] Pre-push hook runs full Rust + integration test suite successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)