### PR TITLE
Refactor: reuse encode_two_reg_one_imm helper in instruction.rs

### DIFF
--- a/crates/wasm-pvm/src/pvm/instruction.rs
+++ b/crates/wasm-pvm/src/pvm/instruction.rs
@@ -1610,36 +1610,16 @@ impl Instruction {
                 encode_two_reg_one_imm(Opcode::SetGtSImm, *dst, *src, *value)
             }
             Self::LoadIndU32 { dst, base, offset } => {
-                let mut bytes = vec![
-                    Opcode::LoadIndU32 as u8,
-                    (*base & 0x0F) << 4 | (*dst & 0x0F),
-                ];
-                bytes.extend_from_slice(&encode_imm(*offset));
-                bytes
+                encode_two_reg_one_imm(Opcode::LoadIndU32, *dst, *base, *offset)
             }
             Self::StoreIndU32 { base, src, offset } => {
-                let mut bytes = vec![
-                    Opcode::StoreIndU32 as u8,
-                    (*base & 0x0F) << 4 | (*src & 0x0F),
-                ];
-                bytes.extend_from_slice(&encode_imm(*offset));
-                bytes
+                encode_two_reg_one_imm(Opcode::StoreIndU32, *src, *base, *offset)
             }
             Self::LoadIndU64 { dst, base, offset } => {
-                let mut bytes = vec![
-                    Opcode::LoadIndU64 as u8,
-                    (*base & 0x0F) << 4 | (*dst & 0x0F),
-                ];
-                bytes.extend_from_slice(&encode_imm(*offset));
-                bytes
+                encode_two_reg_one_imm(Opcode::LoadIndU64, *dst, *base, *offset)
             }
             Self::StoreIndU64 { base, src, offset } => {
-                let mut bytes = vec![
-                    Opcode::StoreIndU64 as u8,
-                    (*base & 0x0F) << 4 | (*src & 0x0F),
-                ];
-                bytes.extend_from_slice(&encode_imm(*offset));
-                bytes
+                encode_two_reg_one_imm(Opcode::StoreIndU64, *src, *base, *offset)
             }
             Self::BranchNeImm { reg, value, offset } => {
                 encode_one_reg_one_imm_one_off(Opcode::BranchNeImm, *reg, *value, *offset)
@@ -1724,56 +1704,28 @@ impl Instruction {
             Self::SignExtend16 { dst, src } => encode_two_reg(Opcode::SignExtend16, *dst, *src),
             Self::ZeroExtend16 { dst, src } => encode_two_reg(Opcode::ZeroExtend16, *dst, *src),
             Self::LoadIndU8 { dst, base, offset } => {
-                let mut bytes = vec![Opcode::LoadIndU8 as u8, (*base & 0x0F) << 4 | (*dst & 0x0F)];
-                bytes.extend_from_slice(&encode_imm(*offset));
-                bytes
+                encode_two_reg_one_imm(Opcode::LoadIndU8, *dst, *base, *offset)
             }
             Self::LoadIndI8 { dst, base, offset } => {
-                let mut bytes = vec![Opcode::LoadIndI8 as u8, (*base & 0x0F) << 4 | (*dst & 0x0F)];
-                bytes.extend_from_slice(&encode_imm(*offset));
-                bytes
+                encode_two_reg_one_imm(Opcode::LoadIndI8, *dst, *base, *offset)
             }
             Self::StoreIndU8 { base, src, offset } => {
-                let mut bytes = vec![
-                    Opcode::StoreIndU8 as u8,
-                    (*base & 0x0F) << 4 | (*src & 0x0F),
-                ];
-                bytes.extend_from_slice(&encode_imm(*offset));
-                bytes
+                encode_two_reg_one_imm(Opcode::StoreIndU8, *src, *base, *offset)
             }
             Self::LoadIndU16 { dst, base, offset } => {
-                let mut bytes = vec![
-                    Opcode::LoadIndU16 as u8,
-                    (*base & 0x0F) << 4 | (*dst & 0x0F),
-                ];
-                bytes.extend_from_slice(&encode_imm(*offset));
-                bytes
+                encode_two_reg_one_imm(Opcode::LoadIndU16, *dst, *base, *offset)
             }
             Self::LoadIndI16 { dst, base, offset } => {
-                let mut bytes = vec![
-                    Opcode::LoadIndI16 as u8,
-                    (*base & 0x0F) << 4 | (*dst & 0x0F),
-                ];
-                bytes.extend_from_slice(&encode_imm(*offset));
-                bytes
+                encode_two_reg_one_imm(Opcode::LoadIndI16, *dst, *base, *offset)
             }
             Self::StoreIndU16 { base, src, offset } => {
-                let mut bytes = vec![
-                    Opcode::StoreIndU16 as u8,
-                    (*base & 0x0F) << 4 | (*src & 0x0F),
-                ];
-                bytes.extend_from_slice(&encode_imm(*offset));
-                bytes
+                encode_two_reg_one_imm(Opcode::StoreIndU16, *src, *base, *offset)
             }
             Self::CmovIzImm { dst, cond, value } => {
-                let mut bytes = encode_two_reg(Opcode::CmovIzImm, *dst, *cond);
-                bytes.extend_from_slice(&encode_imm(*value));
-                bytes
+                encode_two_reg_one_imm(Opcode::CmovIzImm, *dst, *cond, *value)
             }
             Self::CmovNzImm { dst, cond, value } => {
-                let mut bytes = encode_two_reg(Opcode::CmovNzImm, *dst, *cond);
-                bytes.extend_from_slice(&encode_imm(*value));
-                bytes
+                encode_two_reg_one_imm(Opcode::CmovNzImm, *dst, *cond, *value)
             }
             Self::StoreImmU8 { address, value } => {
                 encode_two_imm(Opcode::StoreImmU8, *address, *value)
@@ -1838,12 +1790,7 @@ impl Instruction {
                 encode_one_reg_one_imm(Opcode::StoreU64, *src, *address)
             }
             Self::LoadIndI32 { dst, base, offset } => {
-                let mut bytes = vec![
-                    Opcode::LoadIndI32 as u8,
-                    (*base & 0x0F) << 4 | (*dst & 0x0F),
-                ];
-                bytes.extend_from_slice(&encode_imm(*offset));
-                bytes
+                encode_two_reg_one_imm(Opcode::LoadIndI32, *dst, *base, *offset)
             }
             Self::ReverseBytes { dst, src } => encode_two_reg(Opcode::ReverseBytes, *dst, *src),
             // Alternate shift immediates (TwoRegOneImm)


### PR DESCRIPTION
## Summary

- Refactors `Instruction::encode` in `instruction.rs` to reuse the shared `encode_two_reg_one_imm` helper for remaining duplicated `TwoRegOneImm` byte assembly paths.
- Applies the helper to `CmovIzImm`/`CmovNzImm` and indirect load/store variants (`LoadInd{U8,I8,U16,I16,I32,U32,U64}`, `StoreInd{U8,U16,U32,U64}`).
- No behavior change intended; encoding layout remains identical.

Closes #102.

## Validation

- `cargo test -p wasm-pvm instruction`
- `cd tests && bun test layer1/`
- Pre-push hook suite (format, clippy, Rust tests, integration tests) passed on push.

## Benchmark

Command run:

```bash
./tests/utils/benchmark.sh --base main --current issue-102-refactor-two-reg-one-imm
```

## Comparison: main vs issue-102-refactor-two-reg-one-imm

| Benchmark | Size (before) | Size (after) | Size Change | Gas (before) | Gas (after) | Gas Change |
|-----------|--------------|-------------|-------------|-------------|------------|------------|
| add(5,7)             |           66 |           66 |     +0 (+0.0%) |        201 |        201 |     +0 (+0.0%) |
| fib(20)              |          108 |          108 |     +0 (+0.0%) |        270 |        270 |     +0 (+0.0%) |
| factorial(10)        |          100 |          100 |     +0 (+0.0%) |        242 |        242 |     +0 (+0.0%) |
| is_prime(25)         |          160 |          160 |     +0 (+0.0%) |        329 |        329 |     +0 (+0.0%) |
| AS fib(10)           |          266 |          266 |     +0 (+0.0%) |        720 |        720 |     +0 (+0.0%) |
| AS factorial(7)      |          265 |          265 |     +0 (+0.0%) |        707 |        707 |     +0 (+0.0%) |
| AS gcd(2017,200)     |          260 |          260 |     +0 (+0.0%) |        699 |        699 |     +0 (+0.0%) |
| AS decoder           |         1564 |         1564 |     +0 (+0.0%) |      74825 |      74825 |     +0 (+0.0%) |
| AS array             |         1432 |         1432 |     +0 (+0.0%) |      73903 |      73903 |     +0 (+0.0%) |
| anan-as PVM interpreter |        59704 |        59704 |     +0 (+0.0%) |     238187 |     238187 |     +0 (+0.0%) |
| PiP TRAP             |            1 |            1 |     +0 (+0.0%) |      22740 |      22740 |     +0 (+0.0%) |
| PiP add(5,7)         |          201 |          201 |     +0 (+0.0%) |    1174528 |    1174528 |     +0 (+0.0%) |
| PiP AS fib(10)       |          720 |          720 |     +0 (+0.0%) |    1742037 |    1742037 |     +0 (+0.0%) |
| PiP JAM-SDK fib(10)  |        25965 |        25965 |     +0 (+0.0%) |    6724013 |    6724013 |     +0 (+0.0%) |
| PiP Jambrains fib(10) |        62591 |        62591 |     +0 (+0.0%) |    6477457 |    6477457 |     +0 (+0.0%) |
| PiP JADE fib(10)     |        68947 |        68947 |     +0 (+0.0%) |   18318164 |   18318164 |     +0 (+0.0%) |

