### PR TITLE
Fix benchmark branch comparison parsing and trap restore

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -293,3 +293,11 @@ Accumulated knowledge from development. Update after every task.
 - A compact globals/overflow layout directly below `0x40000` can drastically shrink blob sizes, but breaks pvm-in-pvm interpreter compatibility.
 - Empirical result: direct/unit tests can pass while layer4/layer5 pvm-in-pvm suites fail with outer interpreter panic.
 - Conclusion: memory layout changes must always be validated with pvm-in-pvm tests, not just direct execution and layer1.
+
+### Benchmark Comparison Parsing
+
+- `tests/utils/benchmark.sh` emits two different result tables:
+  - Direct: `Benchmark | WASM Size | JAM Size | Gas Used | Time`
+  - PVM-in-PVM: `Benchmark | JAM Size | Outer Gas Used | Time`
+- Branch comparison must parse JAM size and gas from the correct columns per table header (direct rows use columns 3/4; PiP rows use 2/3).
+- With `set -u`, EXIT trap handlers must not depend on function-local variables at exit time; expand local values when installing the trap.


### PR DESCRIPTION
## Summary
- fix `compare_branches()` EXIT trap under `set -u` by expanding `orig_branch` at trap installation time
- fix `generate_comparison()` parsing so direct table rows compare `JAM Size` and `Gas Used` (not `WASM Size` and `JAM Size`)
- make parser header-aware for both direct and PVM-in-PVM sections
- rename comparison header to explicitly `JAM Size`

## Validation
- `bash -n tests/utils/benchmark.sh`
- `./tests/utils/benchmark.sh --base main --current fix/benchmark-script-compare`
- full pre-push checks passed (format, clippy, rust tests, integration tests)

## Benchmark Results
## Comparison: main vs fix/benchmark-script-compare

| Benchmark | JAM Size (before) | JAM Size (after) | Size Change | Gas (before) | Gas (after) | Gas Change |
|-----------|--------------|-------------|-------------|-------------|------------|------------|
| add(5,7)             |          201 |          201 |     +0 (+0.0%) |         39 |         39 |     +0 (+0.0%) |
| fib(20)              |          270 |          270 |     +0 (+0.0%) |        612 |        612 |     +0 (+0.0%) |
| factorial(10)        |          242 |          242 |     +0 (+0.0%) |        269 |        269 |     +0 (+0.0%) |
| is_prime(25)         |          327 |          327 |     +0 (+0.0%) |         78 |         78 |     +0 (+0.0%) |
| AS fib(10)           |          716 |          716 |     +0 (+0.0%) |        325 |        325 |     +0 (+0.0%) |
| AS factorial(7)      |          705 |          705 |     +0 (+0.0%) |        282 |        282 |     +0 (+0.0%) |
| AS gcd(2017,200)     |          694 |          694 |     +0 (+0.0%) |        191 |        191 |     +0 (+0.0%) |
| AS decoder           |        74798 |        74798 |     +0 (+0.0%) |        751 |        751 |     +0 (+0.0%) |
| AS array             |        73879 |        73879 |     +0 (+0.0%) |        648 |        648 |     +0 (+0.0%) |
| anan-as PVM interpreter |       237132 |       237132 |     +0 (+0.0%) |          - |          - |              - |
| PiP TRAP             |            1 |            1 |     +0 (+0.0%) |      22473 |      22473 |     +0 (+0.0%) |
| PiP add(5,7)         |          201 |          201 |     +0 (+0.0%) |    1166318 |    1166318 |     +0 (+0.0%) |
| PiP AS fib(10)       |          716 |          716 |     +0 (+0.0%) |    1718744 |    1718744 |     +0 (+0.0%) |
| PiP JAM-SDK fib(10)  |        25965 |        25965 |     +0 (+0.0%) |    6679627 |    6679627 |     +0 (+0.0%) |
| PiP Jambrains fib(10) |        62591 |        62591 |     +0 (+0.0%) |    6477165 |    6477165 |     +0 (+0.0%) |
| PiP JADE fib(10)     |        68947 |        68947 |     +0 (+0.0%) |   18194112 |   18194112 |     +0 (+0.0%) |
