### PR TITLE
Add Code Size column to benchmark tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,29 +115,29 @@ The compiler pipeline:
 
 All PVM-level optimizations enabled (default):
 
-| Benchmark | WASM size | JAM size | Gas Used |
-|-----------|----------|----------|----------|
-| add(5,7) | 66 B | 201 B | 39 |
-| fib(20) | 108 B | 270 B | 612 |
-| factorial(10) | 100 B | 242 B | 269 |
-| is_prime(25) | 160 B | 327 B | 78 |
-| AS fib(10) | 266 B | 712 B | 325 |
-| AS factorial(7) | 265 B | 701 B | 282 |
-| AS gcd(2017,200) | 260 B | 691 B | 191 |
-| AS decoder | 1.5 KB | 21.0 KB | 751 |
-| AS array | 1.4 KB | 20.1 KB | 648 |
-| anan-as PVM interpreter | 58.3 KB | 179.5 KB | - |
+| Benchmark | WASM size | JAM size | Code size | Gas Used |
+|-----------|----------|----------|-----------|----------|
+| add(5,7) | 66 B | 201 B | 130 B | 39 |
+| fib(20) | 108 B | 270 B | 186 B | 612 |
+| factorial(10) | 100 B | 242 B | 161 B | 269 |
+| is_prime(25) | 160 B | 327 B | 238 B | 78 |
+| AS fib(10) | 266 B | 712 B | 576 B | 325 |
+| AS factorial(7) | 265 B | 701 B | 566 B | 282 |
+| AS gcd(2017,200) | 260 B | 691 B | 562 B | 191 |
+| AS decoder | 1.5 KB | 21.0 KB | 7.0 KB | 751 |
+| AS array | 1.4 KB | 20.1 KB | 6.2 KB | 648 |
+| anan-as PVM interpreter | 58.3 KB | 179.5 KB | 127.2 KB | - |
 
 PVM-in-PVM: programs executed inside the anan-as PVM interpreter (outer gas cost):
 
-| Benchmark | JAM Size | Outer Gas | Direct Gas | Overhead |
-|-----------|----------|-----------|------------|----------|
-| TRAP (interpreter overhead) | 1 B | 22,470 | - | - |
-| add(5,7) | 201 B | 1,176,696 | 39 | 30,172x |
-| AS fib(10) | 712 B | 1,723,810 | 325 | 5,304x |
-| JAM-SDK fib(10)\* | 25.4 KB | 6,679,366 | 42 | 159,509x |
-| Jambrains fib(10)\* | 61.1 KB | 6,477,292 | 1 | 6,477,292x |
-| JADE fib(10)\* | 67.3 KB | 18,193,275 | 504 | 36,098x |
+| Benchmark | JAM Size | Code Size | Outer Gas | Direct Gas | Overhead |
+|-----------|----------|-----------|-----------|------------|----------|
+| TRAP (interpreter overhead) | 21 B | 1 B | 22,470 | - | - |
+| add(5,7) | 201 B | 130 B | 1,176,696 | 39 | 30,172x |
+| AS fib(10) | 712 B | 576 B | 1,723,810 | 325 | 5,304x |
+| JAM-SDK fib(10)\* | 25.4 KB | 16.2 KB | 6,679,366 | 42 | 159,509x |
+| Jambrains fib(10)\* | 61.1 KB | - | 6,477,292 | 1 | 6,477,292x |
+| JADE fib(10)\* | 67.3 KB | 45.7 KB | 18,193,275 | 504 | 36,098x |
 
 \*JAM-SDK fib(10), Jambrains fib(10), and JADE fib(10) exit on unhandled host calls before the fibonacci computation runs. The gas cost reflects program parsing/loading only (26 KB, 61 KB, and 67 KB binaries respectively), not execution.
 

--- a/tests/utils/verify-jam.ts
+++ b/tests/utils/verify-jam.ts
@@ -161,10 +161,12 @@ function readVarU32(data: Buffer, offset: number): { value: number; bytesRead: n
     const value = ((firstByte - 0x80) << 8) | data[offset + 1];
     return { value, bytesRead: 2 };
   } else if (firstByte < 0xe0) {
-    const value = ((firstByte - 0xc0) << 16) | (data[offset + 1] << 8) | data[offset + 2];
+    // Remaining bytes are little-endian
+    const value = ((firstByte - 0xc0) << 16) | data[offset + 1] | (data[offset + 2] << 8);
     return { value, bytesRead: 3 };
   } else {
-    const value = ((firstByte - 0xe0) << 24) | (data[offset + 1] << 16) | (data[offset + 2] << 8) | data[offset + 3];
+    // Remaining bytes are little-endian
+    const value = ((firstByte - 0xe0) << 24) | data[offset + 1] | (data[offset + 2] << 8) | (data[offset + 3] << 16);
     return { value, bytesRead: 4 };
   }
 }


### PR DESCRIPTION
## Summary
- Add a "Code Size" column to both benchmark tables (Optimizations Impact and PVM-in-PVM) showing raw PVM instruction bytes, stripping SPI overhead (metadata, RO/RW data, jump table, mask)
- Fix varint decoding bug in `verify-jam.ts` and `benchmark.sh` where 3+ byte PVM varints were decoded as big-endian instead of little-endian (matching `blob.rs` `encode_var_u32`)
- Upgrade TRAP benchmark from a raw 1-byte `\x00` to a valid minimal SPI blob (21 bytes)

This makes size comparisons more meaningful — e.g., AS decoder is 21 KB JAM but only 7 KB of actual code, showing that most of the blob size comes from RW data.

## Test plan
- [x] `cargo test` passes (all 212 tests)
- [x] `bun run test` passes (412 integration tests)
- [x] `bash -n benchmark.sh` syntax check passes
- [x] Manually verified code size extraction against `verify-jam.ts` output for multiple JAM files

🤖 Generated with [Claude Code](https://claude.com/claude-code)