### PR TITLE
Fix bump-version workflow to use PRs instead of direct push

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   bump:
@@ -41,16 +42,26 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Commit and tag
+      - name: Create branch and commit
         run: |
+          git checkout -b "bump-version/v$SAFE_VERSION"
           git add Cargo.toml Cargo.lock
           git commit -m "Bump version to $SAFE_VERSION"
-          git tag "v$SAFE_VERSION"
 
-      - name: Push commit and tag
-        run: git push origin HEAD "v$SAFE_VERSION"
+      - name: Push branch
+        run: git push origin "bump-version/v$SAFE_VERSION"
 
-      - name: Create draft release
-        run: gh release create "v$SAFE_VERSION" --draft --generate-notes --title "v$SAFE_VERSION"
+      - name: Create Pull Request
+        run: |
+          gh pr create \
+            --title "Bump version to $SAFE_VERSION" \
+            --body "Automated version bump to $SAFE_VERSION." \
+            --base main \
+            --head "bump-version/v$SAFE_VERSION"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,36 @@
+name: Tag and Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create tag and draft release
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'Bump version to')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from PR title
+        run: |
+          VERSION=$(echo "${{ github.event.pull_request.title }}" | sed 's/Bump version to //')
+          echo "SAFE_VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Create tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v$SAFE_VERSION"
+          git push origin "v$SAFE_VERSION"
+
+      - name: Create draft release
+        run: gh release create "v$SAFE_VERSION" --draft --generate-notes --title "v$SAFE_VERSION"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Split bump-version workflow into two workflows to comply with branch protection rules requiring PRs
- `bump-version.yml` now creates a PR with version changes and enables auto-merge
- `tag-release.yml` (new) creates the git tag and draft release after PR is merged

## Problem
The bump-version workflow failed with:
```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
```

## Solution
1. **bump-version.yml**: Creates branch `bump-version/vX.Y.Z`, pushes, creates PR, enables auto-merge
2. **tag-release.yml**: Triggers on PR merge, creates tag `vX.Y.Z` and draft release

## Flow
Trigger bump workflow → PR created → auto-merge after checks pass → tag + release created