### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-pvm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "inkwell",
  "proptest",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-pvm-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/fluffylabs/wasm-pvm"
 
 [workspace.dependencies]
-wasm-pvm = { path = "crates/wasm-pvm", version = "0.3.0" }
+wasm-pvm = { path = "crates/wasm-pvm", version = "0.4.0" }
 wasm-encoder = "0.219"
 wasmparser = "0.219"
 wat = "1"


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.3.0 to 0.4.0

## Changes
- Updated `Cargo.toml` workspace package version
- Updated workspace dependency version for `wasm-pvm`
- `Cargo.lock` updated automatically via `cargo check`