### PR TITLE
test: cover secondary entry reachability in DFE

### DIFF
--- a/crates/wasm-pvm/src/translate/dead_function_elimination.rs
+++ b/crates/wasm-pvm/src/translate/dead_function_elimination.rs
@@ -238,4 +238,20 @@ mod tests {
         assert!(reachable.contains(&1)); // helper referenced via table/call_indirect
         assert!(!reachable.contains(&2)); // dead
     }
+
+    #[test]
+    fn secondary_entry_reachable() {
+        let reachable = reachable_from_wat(
+            r#"(module
+                (func $main (export "main") (result i32) (i32.const 1))
+                (func $main2 (export "main2") (result i32) (call $helper))
+                (func $helper (result i32) (i32.const 2))
+                (func $dead (result i32) (i32.const 99))
+            )"#,
+        );
+        assert!(reachable.contains(&0)); // main
+        assert!(reachable.contains(&1)); // main2 secondary entry
+        assert!(reachable.contains(&2)); // helper referenced by main2
+        assert!(!reachable.contains(&3)); // dead
+    }
 }


### PR DESCRIPTION
The earlier split took the indirect/table case out on its own, which leaves the secondary entry point case as the remaining bit of DFE coverage that still felt worth making explicit. This just makes sure `main2` keeps its own call chain alive instead of looking dead from the primary entry alone.