### PR TITLE
feat: support is_authorized as primary entrypoint

### DIFF
--- a/crates/wasm-pvm/src/translate/wasm_module.rs
+++ b/crates/wasm-pvm/src/translate/wasm_module.rs
@@ -198,8 +198,14 @@ impl<'a> WasmModule<'a> {
                         if export.kind == wasmparser::ExternalKind::Func {
                             exported_wasm_func_indices.push(export.index);
                             let is_imported = export.index < num_imported_funcs;
-                            let is_main_name =
-                                matches!(export.name, "main" | "refine" | "refine_ext");
+                            let is_main_name = matches!(
+                                export.name,
+                                "main"
+                                    | "refine"
+                                    | "refine_ext"
+                                    | "is_authorized"
+                                    | "is_authorized_ext"
+                            );
                             let is_secondary_name =
                                 matches!(export.name, "main2" | "accumulate" | "accumulate_ext");
                             if is_imported && (is_main_name || is_secondary_name) {
@@ -212,7 +218,10 @@ impl<'a> WasmModule<'a> {
                                 "main" => {
                                     main_func_idx = Some(export.index);
                                 }
-                                "refine" | "refine_ext" if main_func_idx.is_none() => {
+                                "refine" | "refine_ext" | "is_authorized"
+                                | "is_authorized_ext"
+                                    if main_func_idx.is_none() =>
+                                {
                                     main_func_idx = Some(export.index);
                                 }
                                 "main2" => {

--- a/crates/wasm-pvm/src/translate/wasm_module.rs
+++ b/crates/wasm-pvm/src/translate/wasm_module.rs
@@ -218,8 +218,7 @@ impl<'a> WasmModule<'a> {
                                 "main" => {
                                     main_func_idx = Some(export.index);
                                 }
-                                "refine" | "refine_ext" | "is_authorized"
-                                | "is_authorized_ext"
+                                "refine" | "refine_ext" | "is_authorized" | "is_authorized_ext"
                                     if main_func_idx.is_none() =>
                                 {
                                     main_func_idx = Some(export.index);


### PR DESCRIPTION
## Summary
- Add `is_authorized` and `is_authorized_ext` as aliases for the primary entry point (PC=0), alongside existing `refine`/`refine_ext` names
- Supports JAM services that use `is_authorized` as their service entry function

## Benchmark

No codegen changes — only entry point name detection, so no benchmark impact.

## Test plan
- [x] All 134 Rust unit tests pass
- [x] All 442 integration tests pass
- [x] Clippy + rustfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)