### PR TITLE
tests: drop --concurrent from test:light to stabilise blake2b suite

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "bun build.ts",
     "test": "bun run build && bun run test:light",
-    "test:light": "bun test --concurrent layer1/ layer2 layer3/",
+    "test:light": "bun test layer1/ layer2 layer3/",
     "test:layer1": "bun run build && bun test layer1/",
     "test:layer2": "bun run build && bun test layer2/",
     "test:layer3": "bun run build && bun test layer3/",


### PR DESCRIPTION
## Summary

`bun run test` (which calls `test:light`, `bun test --concurrent layer1/ layer2/ layer3/`) reliably fails locally with 13 blake2b timeouts at ~5000ms — the four heaviest cases (`size edges out_len=32 input=257`, `output length endpoints out_len=1`, `out_len=64`, `out_len=33`) plus the seeded-random differential hitting its own per-test budget. All 13 share the same failure mode: the anan-as subprocess takes too long to finish under CPU contention from other in-file concurrent tests also spawning node subprocesses.

Reproduced on a fresh `origin/main` checkout (467 pass / 13 fail, identical named tests) to confirm this is pre-existing environmental flakiness, not caused by any recent change.

## Fix

Drop `--concurrent` from `test:light`. Tests within each file run sequentially (blake2b tests no longer race with each other), and files still run in parallel across bun's default worker pool.

## Verification

Measured 3 runs in each configuration on the same machine:

| Configuration | Result | Runtime |
|---|---|---|
| `bun test --concurrent layer1/ layer2/ layer3/` | 467 pass / 13 fail (reliable) | ~55s |
| `bun test layer1/ layer2/ layer3/` | 480 pass / 0 fail × 3 | ~53s |

Same wall-clock, no flakiness. The `--concurrent` flag in this mix was actively hurting — the extra in-file parallelism created subprocess contention that exceeded the individual 5000ms budget without buying throughput.

## Alternative considered

Raising the per-test timeout (e.g. `bun test --concurrent --timeout 30000`) also makes the suite green, but it masks the underlying contention instead of fixing it and adds an arbitrary number to maintain. Dropping `--concurrent` is the smaller diff with the same outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)