### PR TITLE
feat: trap-floats mode + per-operator location diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,8 @@ wasm-pvm = { version = "0.5.2", default-features = false }
 - **Inline threshold**: `OptimizationFlags.inline_threshold: Option<u32>` (CLI `--inline-threshold N`) controls inlining aggressiveness. Functions with more than N LLVM IR instructions are marked `noinline`. Lower values = less inlining = smaller code. Default: `Some(5)` — only tiny helpers (setters, getters) are inlined. Use `None` (or `225` on CLI) for LLVM's default behavior.
 - **ecalli:N in import maps**: Import map files (`.imports`) support `name = ecalli:N` syntax in addition to `trap` and `nop`. This generates PVM `Ecalli` instructions directly from named imports, loading WASM call arguments into data registers (r7-r12) before invoking ecalli index N.
 - **Non-leaf r7/r8 allocation is not feasible** (investigated, not implemented): Same root cause as callee-saved state preservation after calls — `operand_reg()` returns the allocated register directly as a source operand for memory lowering, where it may be used as both source and destination for address calculations, clobbering the preserved value. See `docs/src/learnings.md` "Non-Leaf r7/r8 Allocation" for details.
+- **`--trap-floats` (`CompileOptions.trap_floats`)**: Feature gate (not an optimization) that replaces every f32/f64 operator with a runtime trap so compilation can finish past the float wall. Implemented in `llvm_frontend/function_builder.rs::emit_float_trap` via `@llvm.trap()` + LLVM unreachable; the PVM backend lowers `llvm.trap` to `Instruction::Trap` in `llvm_backend/intrinsics.rs::lower_llvm_intrinsic`. Critical: do NOT use bare `unreachable` (LLVM's `simplifycfg` folds branches whose only path leads to it as UB, silently deleting float-only if-arms) and do NOT set `self.unreachable = true` in the frontend (would leave function-result phis without an incoming branch). See `docs/src/trap-floats.md` and `docs/src/learnings.md` "Trap-Floats Lowering". Float operators covered are enumerated in `float_op_stack_effect` (≈60 MVP ops; SIMD float ops not included).
+- **Operator-error location wrapping**: When the WASM operator dispatcher (`function_builder.rs::translate_operator`) returns an error, `translate_function` wraps it in `Error::Located { func_idx, func_name, op_offset, source }`. Function names come from the WASM `name` custom section, then export name, then `wasm_func_<idx>` — see `WasmModule::local_function_display_name`. Errors emitted later (in `llvm_backend/*` or `translate/adapter_merge.rs`) do NOT get this wrapping; they fire after the WASM byte offset has been lost.
 
 ---
 
@@ -273,6 +275,9 @@ wasm-pvm = { version = "0.5.2", default-features = false }
 | Understand/modify native WASM runner | `tests/helpers/wasm-runner.ts` | Native WASM runner (WAT→WASM via wabt, Bun WebAssembly) |
 | Define differential test suite | `tests/helpers/suite.ts` | `defineDifferentialSuite()` + `skipDifferential` flag |
 | Add/aggregate differential tests | `tests/differential/differential.test.ts` | Import suites + call `defineDifferentialSuite()` |
+| Modify trap-floats lowering | `llvm_frontend/function_builder.rs::emit_float_trap` + `float_op_stack_effect` | Frontend emits `@llvm.trap()` + LLVM unreachable; backend lowers `llvm.trap` in `llvm_backend/intrinsics.rs::lower_llvm_intrinsic`. See `docs/src/trap-floats.md`. |
+| Add/edit trap-floats tests | `crates/wasm-pvm/tests/float_handling.rs` (Rust unit) + `tests/layer1/trap-floats.test.ts` (CLI + runtime trap) | Compile-time + run-time coverage |
+| Diagnostic location wrapping | `Error::Located` (in `error.rs`) wrapped at `function_builder.rs::translate_function` | Function name from `WasmModule::local_function_display_name`, op byte offset from `into_iter_with_offsets()` |
 
 ---
 

--- a/crates/wasm-pvm-cli/src/main.rs
+++ b/crates/wasm-pvm-cli/src/main.rs
@@ -126,6 +126,14 @@ enum Commands {
             help = "Override maximum memory pages (default: 16 = 1 MB, each page = 64 KB)"
         )]
         max_memory: Option<u32>,
+
+        #[arg(
+            long,
+            help = "Replace every f32/f64 operator with a runtime trap instead of failing \
+                    compilation. Lets you push past the float wall to see what other \
+                    unsupported features the module uses."
+        )]
+        trap_floats: bool,
     },
 }
 
@@ -162,6 +170,7 @@ fn main() -> Result<()> {
             no_caller_saved_alloc,
             no_lazy_spill,
             max_memory,
+            trap_floats,
         } => {
             let wasm = read_wasm(&input)?;
 
@@ -210,6 +219,7 @@ fn main() -> Result<()> {
                         .or(OptimizationFlags::default().inline_threshold),
                 },
                 max_memory_pages: max_memory,
+                trap_floats,
             };
 
             let start = Instant::now();

--- a/crates/wasm-pvm/src/error.rs
+++ b/crates/wasm-pvm/src/error.rs
@@ -21,6 +21,18 @@ pub enum Error {
 
     #[error("Internal error: {0}")]
     Internal(String),
+
+    /// Wrapper attaching the source WASM operator location to a translation error.
+    /// Produced by the function-body translator so users can pinpoint which operator
+    /// in which function caused an unsupported-feature failure.
+    #[error("{source} (in function #{func_idx} '{func_name}' at byte offset 0x{op_offset:x})")]
+    Located {
+        func_idx: usize,
+        func_name: String,
+        op_offset: usize,
+        #[source]
+        source: Box<Error>,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/wasm-pvm/src/error.rs
+++ b/crates/wasm-pvm/src/error.rs
@@ -25,13 +25,18 @@ pub enum Error {
     /// Wrapper attaching the source WASM operator location to a translation error.
     /// Produced by the function-body translator so users can pinpoint which operator
     /// in which function caused an unsupported-feature failure.
-    #[error("{source} (in function #{func_idx} '{func_name}' at byte offset 0x{op_offset:x})")]
+    ///
+    /// The inner error is named `cause` (not `source`) deliberately: thiserror
+    /// auto-treats a field named `source` as the chain link, which would make
+    /// anyhow print the same message twice — once via this variant's Display
+    /// (which interpolates `{cause}`) and once via walking `.source()`.
+    /// Pattern-matching on the variant still gives direct access via `cause`.
+    #[error("{cause} (in function #{func_idx} '{func_name}' at byte offset 0x{op_offset:x})")]
     Located {
         func_idx: usize,
         func_name: String,
         op_offset: usize,
-        #[source]
-        source: Box<Error>,
+        cause: Box<Error>,
     },
 }
 

--- a/crates/wasm-pvm/src/llvm_backend/intrinsics.rs
+++ b/crates/wasm-pvm/src/llvm_backend/intrinsics.rs
@@ -107,6 +107,13 @@ pub fn lower_llvm_intrinsic<'ctx>(
         return Ok(());
     }
 
+    // llvm.trap — emit a real trap. Used by `--trap-floats` mode in place of
+    // bare `unreachable` (which simplifycfg folds away as UB).
+    if name == "llvm.trap" {
+        e.emit(Instruction::Trap);
+        return Ok(());
+    }
+
     let slot = result_slot(e, instr)?;
 
     // llvm.smax / llvm.smin / llvm.umax / llvm.umin — integer min/max intrinsics.

--- a/crates/wasm-pvm/src/llvm_frontend/function_builder.rs
+++ b/crates/wasm-pvm/src/llvm_frontend/function_builder.rs
@@ -24,6 +24,67 @@ fn llvm_err<T>(result: std::result::Result<T, BuilderError>) -> Result<T> {
     result.map_err(|e| Error::Internal(format!("LLVM builder error: {e:?}")))
 }
 
+/// Stack effect (pop count, push count) for f32/f64 WebAssembly operators.
+/// Returns `None` for non-float operators. Used by `--trap-floats` mode to
+/// adjust the operand stack after replacing a float operator with a trap.
+///
+/// All values on the i64-uniform operand stack are 64-bit integers regardless
+/// of source WASM type, so push counts here just track how many entries the
+/// operator would have produced — the placeholder values are zeros.
+///
+/// Several arm bodies are identical `(1, 1)` / `(2, 1)` tuples but the arms
+/// stay grouped by *category* (loads vs unary vs comparisons vs conversions)
+/// so future readers can see exactly which operators were considered.
+#[allow(clippy::too_many_lines, clippy::match_same_arms)]
+fn float_op_stack_effect(op: &Operator) -> Option<(usize, usize)> {
+    use Operator::{
+        F32Abs, F32Add, F32Ceil, F32Const, F32ConvertI32S, F32ConvertI32U, F32ConvertI64S,
+        F32ConvertI64U, F32Copysign, F32DemoteF64, F32Div, F32Eq, F32Floor, F32Ge, F32Gt, F32Le,
+        F32Load, F32Lt, F32Max, F32Min, F32Mul, F32Ne, F32Nearest, F32Neg, F32ReinterpretI32,
+        F32Sqrt, F32Store, F32Sub, F32Trunc, F64Abs, F64Add, F64Ceil, F64Const, F64ConvertI32S,
+        F64ConvertI32U, F64ConvertI64S, F64ConvertI64U, F64Copysign, F64Div, F64Eq, F64Floor,
+        F64Ge, F64Gt, F64Le, F64Load, F64Lt, F64Max, F64Min, F64Mul, F64Ne, F64Nearest, F64Neg,
+        F64PromoteF32, F64ReinterpretI64, F64Sqrt, F64Store, F64Sub, F64Trunc, I32ReinterpretF32,
+        I32TruncF32S, I32TruncF32U, I32TruncF64S, I32TruncF64U, I32TruncSatF32S, I32TruncSatF32U,
+        I32TruncSatF64S, I32TruncSatF64U, I64ReinterpretF64, I64TruncF32S, I64TruncF32U,
+        I64TruncF64S, I64TruncF64U, I64TruncSatF32S, I64TruncSatF32U, I64TruncSatF64S,
+        I64TruncSatF64U,
+    };
+    Some(match op {
+        // Constants: 0 → 1
+        F32Const { .. } | F64Const { .. } => (0, 1),
+
+        // Loads: 1 (addr) → 1 (value)
+        F32Load { .. } | F64Load { .. } => (1, 1),
+
+        // Stores: 2 (addr, value) → 0
+        F32Store { .. } | F64Store { .. } => (2, 0),
+
+        // Unary float ops: 1 → 1
+        F32Abs | F32Neg | F32Ceil | F32Floor | F32Trunc | F32Nearest | F32Sqrt | F64Abs
+        | F64Neg | F64Ceil | F64Floor | F64Trunc | F64Nearest | F64Sqrt => (1, 1),
+
+        // Binary float ops: 2 → 1
+        F32Add | F32Sub | F32Mul | F32Div | F32Min | F32Max | F32Copysign | F64Add | F64Sub
+        | F64Mul | F64Div | F64Min | F64Max | F64Copysign => (2, 1),
+
+        // Float comparisons: 2 → 1 (i32 result)
+        F32Eq | F32Ne | F32Lt | F32Gt | F32Le | F32Ge | F64Eq | F64Ne | F64Lt | F64Gt | F64Le
+        | F64Ge => (2, 1),
+
+        // Conversions touching float (1 → 1)
+        I32TruncF32S | I32TruncF32U | I32TruncF64S | I32TruncF64U | I64TruncF32S
+        | I64TruncF32U | I64TruncF64S | I64TruncF64U | F32ConvertI32S | F32ConvertI32U
+        | F32ConvertI64S | F32ConvertI64U | F32DemoteF64 | F64ConvertI32S | F64ConvertI32U
+        | F64ConvertI64S | F64ConvertI64U | F64PromoteF32 | I32ReinterpretF32
+        | I64ReinterpretF64 | F32ReinterpretI32 | F64ReinterpretI64 | I32TruncSatF32S
+        | I32TruncSatF32U | I32TruncSatF64S | I32TruncSatF64U | I64TruncSatF32S
+        | I64TruncSatF32U | I64TruncSatF64S | I64TruncSatF64U => (1, 1),
+
+        _ => return None,
+    })
+}
+
 /// WASM control flow frame, tracking LLVM basic blocks and phi nodes.
 enum ControlFrame<'ctx> {
     Block {
@@ -97,6 +158,12 @@ pub struct WasmToLlvm<'ctx> {
     // Type signatures for indirect calls: (num_params, num_results) per type index
     type_signatures: Vec<(usize, usize)>,
 
+    // Module-wide configuration
+    /// When true, every f32/f64 operator is replaced with a runtime trap instead
+    /// of being a compile error. Lets users push past the float wall to see what
+    /// other unsupported features exist downstream.
+    trap_floats: bool,
+
     // Per-function state (reset for each function)
     operand_stack: Vec<IntValue<'ctx>>,
     locals: Vec<PointerValue<'ctx>>,
@@ -141,7 +208,7 @@ struct PvmIntrinsics<'ctx> {
 
 impl<'ctx> WasmToLlvm<'ctx> {
     #[must_use]
-    pub fn new(context: &'ctx Context, module_name: &str) -> Self {
+    pub fn new(context: &'ctx Context, module_name: &str, trap_floats: bool) -> Self {
         let module = context.create_module(module_name);
         let builder = context.create_builder();
         let pvm_intrinsics = Self::declare_pvm_intrinsics(context, &module);
@@ -157,6 +224,7 @@ impl<'ctx> WasmToLlvm<'ctx> {
             type_signatures: Vec::new(),
             functions: Vec::new(),
             globals: Vec::new(),
+            trap_floats,
             operand_stack: Vec::new(),
             locals: Vec::new(),
             current_fn: None,
@@ -261,7 +329,15 @@ impl<'ctx> WasmToLlvm<'ctx> {
             let global_idx = wasm_module.num_imported_funcs as usize + local_idx;
             let func_value = self.functions[global_idx];
             let (num_params, has_return) = wasm_module.function_signatures[global_idx];
-            self.translate_function(func_body, func_value, num_params, has_return)?;
+            let display_name = wasm_module.local_function_display_name(local_idx);
+            self.translate_function(
+                func_body,
+                func_value,
+                num_params,
+                has_return,
+                global_idx,
+                &display_name,
+            )?;
         }
 
         if run_llvm_passes {
@@ -324,6 +400,8 @@ impl<'ctx> WasmToLlvm<'ctx> {
         func_value: FunctionValue<'ctx>,
         num_params: usize,
         has_return: bool,
+        func_idx: usize,
+        func_name: &str,
     ) -> Result<()> {
         self.operand_stack.clear();
         self.locals.clear();
@@ -386,14 +464,22 @@ impl<'ctx> WasmToLlvm<'ctx> {
             stack_depth: 0,
         });
 
-        // Translate operators
-        let ops: Vec<Operator> = func_body
-            .get_operators_reader()?
-            .into_iter()
-            .collect::<std::result::Result<_, _>>()?;
-
-        for op in &ops {
-            self.translate_operator(op)?;
+        // Translate operators with byte-offset tracking so any error from the
+        // operator dispatch can be wrapped in a `Located` variant pointing at
+        // the exact operator within the function body.
+        for entry in func_body.get_operators_reader()?.into_iter_with_offsets() {
+            let (op, op_offset) = entry?;
+            self.translate_operator(&op).map_err(|source| match source {
+                // Avoid double-wrapping: if a deeper translator already attached
+                // a location, keep the innermost one (it's more specific).
+                Error::Located { .. } => source,
+                _ => Error::Located {
+                    func_idx,
+                    func_name: func_name.to_string(),
+                    op_offset,
+                    source: Box::new(source),
+                },
+            })?;
         }
 
         // Verify function ends cleanly (the final End should have popped the fn frame)
@@ -407,6 +493,20 @@ impl<'ctx> WasmToLlvm<'ctx> {
     }
 
     fn translate_operator(&mut self, op: &Operator) -> Result<()> {
+        // Trap-floats mode: convert any f32/f64 operator into an LLVM unreachable
+        // and continue codegen in a fresh block with placeholder operand-stack
+        // values. The trap fires deterministically at runtime; subsequent ops
+        // generate dead code that LLVM will DCE away. We do NOT set
+        // `self.unreachable = true` because the operand stack must keep its
+        // expected shape for the remainder of the function body (in particular,
+        // function-level result phis must still receive an incoming branch).
+        if self.trap_floats
+            && !self.unreachable
+            && let Some((pop, push)) = float_op_stack_effect(op)
+        {
+            return self.emit_float_trap(pop, push);
+        }
+
         // In unreachable code, only track control flow structure for End matching.
         if self.unreachable {
             match op {
@@ -1272,6 +1372,53 @@ impl<'ctx> WasmToLlvm<'ctx> {
 
             _ => Err(Error::Unsupported(format!("{op:?}"))),
         }
+    }
+
+    // ── Trap-floats helper ──
+
+    /// Emit a runtime trap (`@llvm.trap()` + `unreachable`) and continue
+    /// codegen in a fresh basic block. Pops `pop` operand-stack entries for
+    /// the operator's inputs and pushes `push` zero placeholders for its
+    /// outputs. The new block has no live predecessors, so subsequent ops
+    /// translate into provably-dead code that LLVM's DCE removes — but the
+    /// operand stack and control-flow phi nodes stay structurally valid.
+    ///
+    /// Crucially we must NOT emit a bare `unreachable` here. LLVM's
+    /// `simplifycfg` treats `unreachable` as "this code is impossible" and
+    /// folds away conditional branches whose only path leads to one — so a
+    /// float op in an if-arm would silently delete the whole branch instead
+    /// of trapping. `@llvm.trap()` is a side-effecting `noreturn` call that
+    /// the optimizer preserves; the PVM backend lowers it to a `Trap`
+    /// instruction.
+    fn emit_float_trap(&mut self, pop: usize, push: usize) -> Result<()> {
+        let trap_fn = self.llvm_trap_intrinsic()?;
+        llvm_err(self.builder.build_call(trap_fn, &[], "float_trap"))?;
+        llvm_err(self.builder.build_unreachable())?;
+
+        let fn_val = self.current_fn.unwrap();
+        let after_bb = self
+            .context
+            .append_basic_block(fn_val, "after_float_trap");
+        self.builder.position_at_end(after_bb);
+
+        for _ in 0..pop {
+            self.pop()?;
+        }
+        let zero = self.i64_type.const_zero();
+        for _ in 0..push {
+            self.push(zero);
+        }
+        Ok(())
+    }
+
+    /// Look up (and cache via the LLVM module) the `@llvm.trap` intrinsic
+    /// declaration. Not overloaded, so no parameter type list is needed.
+    fn llvm_trap_intrinsic(&self) -> Result<FunctionValue<'ctx>> {
+        let intrinsic = Intrinsic::find("llvm.trap")
+            .ok_or_else(|| Error::Internal("llvm.trap intrinsic not found".to_string()))?;
+        intrinsic
+            .get_declaration(&self.module, &[])
+            .ok_or_else(|| Error::Internal("llvm.trap declaration failed".to_string()))
     }
 
     // ── Stack helpers ──

--- a/crates/wasm-pvm/src/llvm_frontend/function_builder.rs
+++ b/crates/wasm-pvm/src/llvm_frontend/function_builder.rs
@@ -469,18 +469,17 @@ impl<'ctx> WasmToLlvm<'ctx> {
         // the exact operator within the function body.
         for entry in func_body.get_operators_reader()?.into_iter_with_offsets() {
             let (op, op_offset) = entry?;
-            self.translate_operator(&op)
-                .map_err(|source| match source {
-                    // Avoid double-wrapping: if a deeper translator already attached
-                    // a location, keep the innermost one (it's more specific).
-                    Error::Located { .. } => source,
-                    _ => Error::Located {
-                        func_idx,
-                        func_name: func_name.to_string(),
-                        op_offset,
-                        source: Box::new(source),
-                    },
-                })?;
+            self.translate_operator(&op).map_err(|cause| match cause {
+                // Avoid double-wrapping: if a deeper translator already attached
+                // a location, keep the innermost one (it's more specific).
+                Error::Located { .. } => cause,
+                _ => Error::Located {
+                    func_idx,
+                    func_name: func_name.to_string(),
+                    op_offset,
+                    cause: Box::new(cause),
+                },
+            })?;
         }
 
         // Verify function ends cleanly (the final End should have popped the fn frame)

--- a/crates/wasm-pvm/src/llvm_frontend/function_builder.rs
+++ b/crates/wasm-pvm/src/llvm_frontend/function_builder.rs
@@ -73,13 +73,13 @@ fn float_op_stack_effect(op: &Operator) -> Option<(usize, usize)> {
         | F64Ge => (2, 1),
 
         // Conversions touching float (1 → 1)
-        I32TruncF32S | I32TruncF32U | I32TruncF64S | I32TruncF64U | I64TruncF32S
-        | I64TruncF32U | I64TruncF64S | I64TruncF64U | F32ConvertI32S | F32ConvertI32U
-        | F32ConvertI64S | F32ConvertI64U | F32DemoteF64 | F64ConvertI32S | F64ConvertI32U
-        | F64ConvertI64S | F64ConvertI64U | F64PromoteF32 | I32ReinterpretF32
-        | I64ReinterpretF64 | F32ReinterpretI32 | F64ReinterpretI64 | I32TruncSatF32S
-        | I32TruncSatF32U | I32TruncSatF64S | I32TruncSatF64U | I64TruncSatF32S
-        | I64TruncSatF32U | I64TruncSatF64S | I64TruncSatF64U => (1, 1),
+        I32TruncF32S | I32TruncF32U | I32TruncF64S | I32TruncF64U | I64TruncF32S | I64TruncF32U
+        | I64TruncF64S | I64TruncF64U | F32ConvertI32S | F32ConvertI32U | F32ConvertI64S
+        | F32ConvertI64U | F32DemoteF64 | F64ConvertI32S | F64ConvertI32U | F64ConvertI64S
+        | F64ConvertI64U | F64PromoteF32 | I32ReinterpretF32 | I64ReinterpretF64
+        | F32ReinterpretI32 | F64ReinterpretI64 | I32TruncSatF32S | I32TruncSatF32U
+        | I32TruncSatF64S | I32TruncSatF64U | I64TruncSatF32S | I64TruncSatF32U
+        | I64TruncSatF64S | I64TruncSatF64U => (1, 1),
 
         _ => return None,
     })
@@ -469,17 +469,18 @@ impl<'ctx> WasmToLlvm<'ctx> {
         // the exact operator within the function body.
         for entry in func_body.get_operators_reader()?.into_iter_with_offsets() {
             let (op, op_offset) = entry?;
-            self.translate_operator(&op).map_err(|source| match source {
-                // Avoid double-wrapping: if a deeper translator already attached
-                // a location, keep the innermost one (it's more specific).
-                Error::Located { .. } => source,
-                _ => Error::Located {
-                    func_idx,
-                    func_name: func_name.to_string(),
-                    op_offset,
-                    source: Box::new(source),
-                },
-            })?;
+            self.translate_operator(&op)
+                .map_err(|source| match source {
+                    // Avoid double-wrapping: if a deeper translator already attached
+                    // a location, keep the innermost one (it's more specific).
+                    Error::Located { .. } => source,
+                    _ => Error::Located {
+                        func_idx,
+                        func_name: func_name.to_string(),
+                        op_offset,
+                        source: Box::new(source),
+                    },
+                })?;
         }
 
         // Verify function ends cleanly (the final End should have popped the fn frame)
@@ -1396,9 +1397,7 @@ impl<'ctx> WasmToLlvm<'ctx> {
         llvm_err(self.builder.build_unreachable())?;
 
         let fn_val = self.current_fn.unwrap();
-        let after_bb = self
-            .context
-            .append_basic_block(fn_val, "after_float_trap");
+        let after_bb = self.context.append_basic_block(fn_val, "after_float_trap");
         self.builder.position_at_end(after_bb);
 
         for _ in 0..pop {

--- a/crates/wasm-pvm/src/llvm_frontend/mod.rs
+++ b/crates/wasm-pvm/src/llvm_frontend/mod.rs
@@ -23,7 +23,7 @@ use crate::translate::wasm_module::WasmModule;
 /// `run_llvm_passes` gates the entire optimization pipeline (all three phases).
 /// `run_inlining` enables/disables Phase 2 independently (requires `run_llvm_passes = true`).
 /// `reachable_locals` when `Some`, limits translation to only those local function indices.
-#[allow(clippy::implicit_hasher)]
+#[allow(clippy::implicit_hasher, clippy::fn_params_excessive_bools)]
 pub fn translate_wasm_to_llvm<'ctx>(
     context: &'ctx Context,
     wasm_module: &WasmModule,
@@ -31,8 +31,9 @@ pub fn translate_wasm_to_llvm<'ctx>(
     run_inlining: bool,
     inline_threshold: Option<u32>,
     reachable_locals: Option<&BTreeSet<usize>>,
+    trap_floats: bool,
 ) -> Result<Module<'ctx>> {
-    let translator = WasmToLlvm::new(context, "wasm_module");
+    let translator = WasmToLlvm::new(context, "wasm_module", trap_floats);
     translator.translate_module(
         wasm_module,
         run_llvm_passes,

--- a/crates/wasm-pvm/src/translate/mod.rs
+++ b/crates/wasm-pvm/src/translate/mod.rs
@@ -125,6 +125,11 @@ pub struct CompileOptions {
     /// Override the maximum memory pages (memory.grow ceiling).
     /// When set, this takes precedence over both the WASM-declared max and the compiler default.
     pub max_memory_pages: Option<u32>,
+    /// When true, replace every f32/f64 operator with a runtime trap instead of
+    /// failing compilation. Useful for diagnosing what other unsupported features
+    /// a WASM module uses past the float wall. JAMs run normally if execution
+    /// never reaches a float operator; otherwise they trap deterministically.
+    pub trap_floats: bool,
 }
 
 // Re-export register constants from abi module
@@ -305,6 +310,7 @@ fn compile_via_llvm(module: &WasmModule, options: &CompileOptions) -> Result<Com
         options.optimizations.inlining,
         options.optimizations.inline_threshold,
         reachable_locals.as_ref(),
+        options.trap_floats,
     )?;
 
     // Calculate RO_DATA offsets and lengths for passive data segments

--- a/crates/wasm-pvm/src/translate/wasm_module.rs
+++ b/crates/wasm-pvm/src/translate/wasm_module.rs
@@ -63,6 +63,10 @@ pub struct WasmModule<'a> {
     pub imported_func_type_indices: Vec<u32>,
     /// Names of imported functions.
     pub imported_func_names: Vec<String>,
+    /// Optional display names for local functions, indexed by local function index.
+    /// Populated from the WASM "name" custom section, falling back to export names.
+    /// `None` means no name is known; callers should use a synthetic identifier.
+    pub local_function_names: Vec<Option<String>>,
 
     // --- Derived data ---
     /// Local function index of the main entry point.
@@ -102,6 +106,17 @@ pub struct WasmModule<'a> {
 }
 
 impl<'a> WasmModule<'a> {
+    /// Display name for a local function: name-section entry, exported name, or
+    /// the synthetic `wasm_func_<global_idx>` placeholder.
+    #[must_use]
+    pub fn local_function_display_name(&self, local_idx: usize) -> String {
+        if let Some(Some(name)) = self.local_function_names.get(local_idx) {
+            return name.clone();
+        }
+        let global_idx = self.num_imported_funcs as usize + local_idx;
+        format!("wasm_func_{global_idx}")
+    }
+
     /// Parse and validate a WASM binary, producing a `WasmModule` with all derived data.
     pub fn parse(wasm: &'a [u8]) -> Result<Self> {
         wasmparser::validate(wasm)
@@ -123,6 +138,15 @@ impl<'a> WasmModule<'a> {
         let mut num_imported_funcs: u32 = 0;
         let mut imported_func_type_indices: Vec<u32> = Vec::new();
         let mut imported_func_names: Vec<String> = Vec::new();
+        // Raw (global_func_idx, name) pairs collected from the WASM "name" custom
+        // section. Resolved into `local_function_names` after parsing finishes,
+        // since the name section may precede the import section in pathological
+        // modules and `num_imported_funcs` may not yet be known.
+        let mut name_section_entries: Vec<(u32, String)> = Vec::new();
+        // First export name observed for each global function index (fallback when
+        // the name section is absent).
+        let mut export_name_by_global_idx: std::collections::BTreeMap<u32, String> =
+            std::collections::BTreeMap::new();
 
         for payload in Parser::new(0).parse_all(wasm) {
             match payload? {
@@ -211,6 +235,9 @@ impl<'a> WasmModule<'a> {
                         let export = export?;
                         if export.kind == wasmparser::ExternalKind::Func {
                             exported_wasm_func_indices.push(export.index);
+                            export_name_by_global_idx
+                                .entry(export.index)
+                                .or_insert_with(|| export.name.to_string());
                             let is_imported = export.index < num_imported_funcs;
                             let is_main_name = matches!(
                                 export.name,
@@ -272,6 +299,20 @@ impl<'a> WasmModule<'a> {
                                     offset: None,
                                     data: data.data.to_vec(),
                                 });
+                            }
+                        }
+                    }
+                }
+                Payload::CustomSection(custom) => {
+                    if let wasmparser::KnownCustom::Name(reader) = custom.as_known() {
+                        for subsection in reader {
+                            let subsection = subsection?;
+                            if let wasmparser::Name::Function(map) = subsection {
+                                for naming in map {
+                                    let naming = naming?;
+                                    name_section_entries
+                                        .push((naming.index, naming.name.to_string()));
+                                }
                             }
                         }
                     }
@@ -402,6 +443,25 @@ impl<'a> WasmModule<'a> {
             .unwrap_or(DEFAULT_MAX_PAGES)
             .max(memory_limits.initial_pages);
 
+        // Resolve display names for local functions: prefer the name section,
+        // fall back to the export section.
+        let mut local_function_names: Vec<Option<String>> = vec![None; functions.len()];
+        for (global_idx, name) in &name_section_entries {
+            if let Some(local_idx) = (*global_idx).checked_sub(num_imported_funcs)
+                && let Some(slot) = local_function_names.get_mut(local_idx as usize)
+            {
+                *slot = Some(name.clone());
+            }
+        }
+        for (global_idx, name) in &export_name_by_global_idx {
+            if let Some(local_idx) = (*global_idx).checked_sub(num_imported_funcs)
+                && let Some(slot) = local_function_names.get_mut(local_idx as usize)
+                && slot.is_none()
+            {
+                *slot = Some(name.clone());
+            }
+        }
+
         Ok(WasmModule {
             functions,
             func_types,
@@ -413,6 +473,7 @@ impl<'a> WasmModule<'a> {
             num_imported_funcs,
             imported_func_type_indices,
             imported_func_names,
+            local_function_names,
             main_func_local_idx,
             has_secondary_entry,
             secondary_entry_local_idx,

--- a/crates/wasm-pvm/src/translate/wasm_module.rs
+++ b/crates/wasm-pvm/src/translate/wasm_module.rs
@@ -702,6 +702,64 @@ mod tests {
     }
 
     #[test]
+    fn display_name_uses_name_section_entry() {
+        // `$identifier` in WAT becomes a name-section entry; that wins over
+        // the export alias.
+        let wasm = wat::parse_str(
+            r#"(module
+                (func $canonical (export "main") (param i32 i32) (result i64) (i64.const 0))
+            )"#,
+        )
+        .expect("valid WAT");
+        let module = WasmModule::parse(&wasm).expect("valid module");
+        assert_eq!(module.local_function_display_name(0), "canonical");
+    }
+
+    #[test]
+    fn display_name_falls_back_to_export_name() {
+        // No `$identifier` → no name-section entry → display falls back to the
+        // export name.
+        let wasm = wat::parse_str(
+            r#"(module
+                (func (export "main") (param i32 i32) (result i64) (i64.const 0))
+                (func (export "helper"))
+            )"#,
+        )
+        .expect("valid WAT");
+        let module = WasmModule::parse(&wasm).expect("valid module");
+        assert_eq!(module.local_function_display_name(0), "main");
+        assert_eq!(module.local_function_display_name(1), "helper");
+    }
+
+    #[test]
+    fn display_name_synthetic_when_unexported_and_no_name_section() {
+        // Second function has no export and no `$identifier` → both fallback
+        // sources are empty → synthetic `wasm_func_<global_idx>` name.
+        let wasm = wat::parse_str(
+            r#"(module
+                (func (export "main") (param i32 i32) (result i64) (i64.const 0))
+                (func)
+            )"#,
+        )
+        .expect("valid WAT");
+        let module = WasmModule::parse(&wasm).expect("valid module");
+        // No imports, so local_idx 1 → global_idx 1 → "wasm_func_1".
+        assert_eq!(module.local_function_display_name(1), "wasm_func_1");
+    }
+
+    #[test]
+    fn display_name_out_of_bounds_returns_synthetic_no_panic() {
+        let wasm = wat::parse_str(
+            r#"(module (func (export "main") (param i32 i32) (result i64) (i64.const 0)))"#,
+        )
+        .expect("valid WAT");
+        let module = WasmModule::parse(&wasm).expect("valid module");
+        // Past the end of `local_function_names` must fall through to the
+        // synthetic formatter rather than panicking.
+        assert_eq!(module.local_function_display_name(99), "wasm_func_99");
+    }
+
+    #[test]
     fn imported_entry_export_returns_error() {
         let wasm = wat::parse_str(
             r#"(module

--- a/crates/wasm-pvm/tests/float_handling.rs
+++ b/crates/wasm-pvm/tests/float_handling.rs
@@ -1,0 +1,314 @@
+//! Tests for float-operator diagnostics and `--trap-floats` mode.
+//!
+//! PVM has no floating-point instructions; the compiler rejects any f32/f64
+//! operator by default. These tests verify two related behaviours:
+//!
+//! 1. **Diagnostics**: when compilation fails on an unsupported operator, the
+//!    error message identifies the function (index + display name) and the
+//!    byte offset of the operator within the function body.
+//!
+//! 2. **`--trap-floats`** (`CompileOptions::trap_floats` = true): every f32/f64
+//!    operator is replaced with a runtime trap so the rest of the function (and
+//!    the rest of the module) can still be compiled. This lets users find out
+//!    what *other* unsupported features a module uses past the float wall.
+
+use wasm_pvm::test_harness::*;
+use wasm_pvm::{CompileOptions, Error, Opcode};
+
+// ──────────────────────────────────────────────────────────────────────────
+// Diagnostics: location info on failure
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Compiling a module with `f64.add` should fail with a `Located` error that
+/// names the function and the operator's byte offset. When the WAT source
+/// gives the function an explicit identifier (`$name`), that identifier
+/// becomes a name-section entry and the diagnostic prefers it over the export
+/// alias — name section is the canonical debug name.
+#[test]
+fn float_op_fails_with_function_name_and_offset() {
+    let wat = r#"
+        (module
+            (func $float_user (export "main") (param f64 f64) (result f64)
+                local.get 0
+                local.get 1
+                f64.add
+            )
+        )
+    "#;
+
+    let err = compile_wat(wat)
+        .err()
+        .expect("expected compilation to fail on f64.add");
+    let Error::Located {
+        func_idx,
+        func_name,
+        op_offset,
+        source,
+    } = err
+    else {
+        panic!("expected Error::Located, got something else");
+    };
+
+    assert_eq!(func_idx, 0, "only one function exists in this module");
+    assert_eq!(
+        func_name, "float_user",
+        "name section ($float_user) should win over export alias (main)"
+    );
+    assert!(op_offset > 0, "op offset should point into function body");
+
+    let msg = source.to_string();
+    assert!(
+        msg.contains("Unsupported") || msg.contains("Float"),
+        "inner error should describe the unsupported operator, got: {msg}"
+    );
+}
+
+/// When the WAT has only an export name (no `$identifier`), the diagnostic
+/// falls back to the export name.
+#[test]
+fn export_name_fallback_when_name_section_empty() {
+    let wat = r#"
+        (module
+            (func (export "main") (param f64 f64) (result f64)
+                local.get 0
+                local.get 1
+                f64.add
+            )
+        )
+    "#;
+    let err = compile_wat(wat)
+        .err()
+        .expect("expected compilation to fail on f64.add");
+    let Error::Located { func_name, .. } = err else {
+        panic!("expected Error::Located");
+    };
+    assert_eq!(func_name, "main");
+}
+
+/// Display string for a `Located` error must include the function name and
+/// hex offset, so users can grep for the location in CI logs.
+#[test]
+fn located_error_display_includes_context() {
+    let wat = r#"
+        (module
+            (func (export "main") (param f64 f64) (result f64)
+                local.get 0
+                local.get 1
+                f64.add
+            )
+        )
+    "#;
+
+    let err = compile_wat(wat)
+        .err()
+        .expect("expected compilation to fail");
+    let display = err.to_string();
+    assert!(
+        display.contains("'main'"),
+        "display should mention function name, got: {display}"
+    );
+    assert!(
+        display.contains("byte offset 0x"),
+        "display should include hex byte offset, got: {display}"
+    );
+}
+
+/// Non-float unsupported features (e.g. `data.drop`) should also receive a
+/// `Located` wrapper — the diagnostic improvement isn't float-specific.
+#[test]
+fn non_float_unsupported_op_also_gets_location() {
+    let wat = r#"
+        (module
+            (memory 1)
+            (data $d0 "hello")
+            (func (export "main") (result i32)
+                data.drop $d0
+                i32.const 0
+            )
+        )
+    "#;
+
+    let err = compile_wat(wat)
+        .err()
+        .expect("expected compilation to fail on data.drop");
+    let Error::Located {
+        func_name, source, ..
+    } = err
+    else {
+        panic!("expected Error::Located, got: {err:?}");
+    };
+    assert_eq!(func_name, "main");
+    assert!(
+        source.to_string().contains("data.drop"),
+        "inner error should mention data.drop, got: {source}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// --trap-floats: float ops compile to runtime traps
+// ──────────────────────────────────────────────────────────────────────────
+
+/// With `trap_floats: true`, `f64.add` no longer fails compilation. The module
+/// produces valid PVM bytecode containing at least one `Trap` instruction
+/// (from the float operator) plus the entry-header trap.
+#[test]
+fn trap_floats_lets_f64_add_compile() {
+    let wat = r#"
+        (module
+            (func (export "main") (param i64) (result i64)
+                f64.const 1.0
+                f64.const 2.0
+                f64.add
+                drop
+                local.get 0
+            )
+        )
+    "#;
+
+    let opts = CompileOptions {
+        trap_floats: true,
+        ..CompileOptions::default()
+    };
+    let program = compile_wat_with_options(wat, &opts).expect("trap-floats should compile");
+    let instructions = extract_instructions(&program);
+
+    let trap_count = count_opcode(&instructions, Opcode::Trap);
+    // At minimum: the entry-header trap (placeholder when no secondary entry)
+    // plus one trap per float operator we converted (3 here: two consts + add).
+    // The exact count depends on optimizer DCE, but >= 2 is a solid lower bound:
+    // entry-header trap + at least one float-op trap.
+    assert!(
+        trap_count >= 2,
+        "expected at least 2 Trap instructions, got {trap_count} in {instructions:?}"
+    );
+}
+
+/// Trap-floats should compile every float-flavoured operator we support, not
+/// just the binary ones. This module exercises a const, a binop, a comparison,
+/// a unary op, and a conversion in a single function — each must be replaced
+/// with a trap without breaking operand-stack tracking.
+#[test]
+fn trap_floats_handles_all_operator_families() {
+    let wat = r#"
+        (module
+            (func (export "main") (param i64) (result i64)
+                ;; constant + binop
+                f64.const 1.5
+                f64.const 2.5
+                f64.add
+                drop
+                ;; unary
+                f32.const 3.0
+                f32.sqrt
+                drop
+                ;; compare → i32
+                f64.const 1.0
+                f64.const 2.0
+                f64.lt
+                drop
+                ;; conversion (i32 → f64 → i32)
+                i32.const 42
+                f64.convert_i32_s
+                i32.trunc_f64_s
+                drop
+                ;; result
+                local.get 0
+            )
+        )
+    "#;
+
+    let opts = CompileOptions {
+        trap_floats: true,
+        ..CompileOptions::default()
+    };
+    let program =
+        compile_wat_with_options(wat, &opts).expect("trap-floats should handle all op families");
+    let instructions = extract_instructions(&program);
+    assert!(
+        has_opcode(&instructions, Opcode::Trap),
+        "expected a Trap from the float operators"
+    );
+}
+
+/// A function with an f32/f64 result type should still compile cleanly under
+/// `--trap-floats`. The function body traps before producing the (placeholder)
+/// return value, so the LLVM IR for the function-end phi must remain valid.
+#[test]
+fn trap_floats_function_returning_float_compiles() {
+    let wat = r#"
+        (module
+            (func (export "main") (param i64) (result i64)
+                call $produce_float
+                drop
+                local.get 0
+            )
+            (func $produce_float (result f64)
+                f64.const 3.14
+            )
+        )
+    "#;
+
+    let opts = CompileOptions {
+        trap_floats: true,
+        ..CompileOptions::default()
+    };
+    let program = compile_wat_with_options(wat, &opts)
+        .expect("function returning f64 should compile with trap-floats");
+    assert!(!extract_instructions(&program).is_empty());
+}
+
+/// A float operator inside one arm of an `if` should trap that arm but leave
+/// the other arm reachable, and the merge-block phi must be satisfied. This
+/// is the trickiest control-flow case for the trap-floats lowering — it caught
+/// a bug during development where setting `self.unreachable = true` left the
+/// result phi without an incoming branch from the trap path.
+#[test]
+fn trap_floats_inside_if_arm_compiles() {
+    let wat = r#"
+        (module
+            (func (export "main") (param i32) (result i64)
+                local.get 0
+                if (result i64)
+                    f64.const 1.0
+                    drop
+                    i64.const 100
+                else
+                    i64.const 200
+                end
+            )
+        )
+    "#;
+
+    let opts = CompileOptions {
+        trap_floats: true,
+        ..CompileOptions::default()
+    };
+    let program = compile_wat_with_options(wat, &opts)
+        .expect("if-arm with float op should compile under trap-floats");
+    let instructions = extract_instructions(&program);
+    assert!(
+        has_opcode(&instructions, Opcode::Trap),
+        "expected a Trap for the float branch"
+    );
+}
+
+/// Default mode (`trap_floats` = false) MUST still reject float ops. We don't
+/// want trap-floats to leak into normal compilation by accident.
+#[test]
+fn default_mode_still_rejects_floats() {
+    let wat = r#"
+        (module
+            (func (export "main") (result i64)
+                f64.const 1.0
+                drop
+                i64.const 0
+            )
+        )
+    "#;
+    let opts = CompileOptions::default();
+    assert!(!opts.trap_floats, "default must be trap_floats=false");
+    let err = compile_wat_with_options(wat, &opts)
+        .err()
+        .expect("default should still fail");
+    assert!(matches!(err, Error::Located { .. }));
+}

--- a/crates/wasm-pvm/tests/float_handling.rs
+++ b/crates/wasm-pvm/tests/float_handling.rs
@@ -43,7 +43,7 @@ fn float_op_fails_with_function_name_and_offset() {
         func_idx,
         func_name,
         op_offset,
-        source,
+        cause,
     } = err
     else {
         panic!("expected Error::Located, got something else");
@@ -56,7 +56,7 @@ fn float_op_fails_with_function_name_and_offset() {
     );
     assert!(op_offset > 0, "op offset should point into function body");
 
-    let msg = source.to_string();
+    let msg = cause.to_string();
     assert!(
         msg.contains("Unsupported") || msg.contains("Float"),
         "inner error should describe the unsupported operator, got: {msg}"
@@ -132,15 +132,15 @@ fn non_float_unsupported_op_also_gets_location() {
         .err()
         .expect("expected compilation to fail on data.drop");
     let Error::Located {
-        func_name, source, ..
+        func_name, cause, ..
     } = err
     else {
         panic!("expected Error::Located, got: {err:?}");
     };
     assert_eq!(func_name, "main");
     assert!(
-        source.to_string().contains("data.drop"),
-        "inner error should mention data.drop, got: {source}"
+        cause.to_string().contains("data.drop"),
+        "inner error should mention data.drop, got: {cause}"
     );
 }
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Getting Started](./getting-started.md)
 - [CLI Usage](./cli-usage.md)
 - [Import Handling](./import-handling.md)
+- [Trap Floats Mode](./trap-floats.md)
 
 # Architecture
 

--- a/docs/src/cli-usage.md
+++ b/docs/src/cli-usage.md
@@ -42,3 +42,27 @@ All non-trivial optimizations are enabled by default. Each can be individually d
 | `--no-fallthrough-jumps` | Skip redundant Jump when target is next block |
 
 See the [Optimizations](./optimizations.md) chapter for details on each.
+
+## Diagnostic & Triage Flags
+
+These flags affect what the compiler accepts or how it reports failures. They
+are *not* optimizations.
+
+| Flag | What it does |
+|------|--------------|
+| `--trap-floats` | Replace every f32/f64 operator with a runtime trap instead of failing compilation. See [Trap Floats Mode](./trap-floats.md). |
+
+When compilation fails on an unsupported operator, the error message includes
+the function index, the function's display name (from the WASM `name` custom
+section, falling back to the export name, then `wasm_func_<idx>`), and the
+operator's byte offset within the function body. Example:
+
+```text
+Error: Compilation failed
+
+Caused by:
+    Unsupported WASM feature: F64Load { memarg: ... } (in function #42 'compute_score' at byte offset 0x1a3)
+```
+
+This makes it possible to grep into the WASM disassembly (`wasm-tools dump`)
+or anan-as source to find the offending site without bisecting the module.

--- a/docs/src/internals/translation.md
+++ b/docs/src/internals/translation.md
@@ -32,6 +32,7 @@ Source: `crates/wasm-pvm/src/translate/`
 - Call return addresses are pre-assigned as jump-table refs `((idx + 1) * 2)` at emission time; fixup resolution accepts direct (`LoadImmJump`) and indirect (`LoadImm` / `LoadImmJumpInd`) return-address carriers.
 - Export parsing tracks `exported_wasm_func_indices` in WASM global index space for dead-function-elimination roots; entry resolution prefers canonical names (`main`, `main2`) over aliases (`refine*`, `accumulate*`) regardless of export order.
 - Entry exports (`main`/`main2` and aliases) must target local (non-imported) functions; imported targets are rejected during parse with `Error::Internal` to avoid index-underflow panics.
+- WASM `name` custom section (subsection 1, function names) is parsed into `local_function_names: Vec<Option<String>>`. `WasmModule::local_function_display_name(local_idx)` returns the name-section entry, falling back to the export name, then `wasm_func_<global_idx>`. Used by the function-body translator to wrap operator-dispatch errors in `Error::Located { func_idx, func_name, op_offset, source }` — the diagnostic surface for unsupported features. Errors emitted later in the pipeline (LLVM-to-PVM lowering, adapter merge) do not get this wrapping; they fire after the WASM byte offset has been lost.
 
 ## Current Memory Layout
 

--- a/docs/src/learnings.md
+++ b/docs/src/learnings.md
@@ -606,3 +606,31 @@ Most `HashMap<BasicBlock, _>` iteration sites in the backend are commutative (e.
 ### Detection
 
 `tests/utils/check-determinism.sh` compiles a diverse set of fixtures N times in separate processes and diffs the output. A single-process cargo test cannot catch these traps because the `HashMap` hasher seed and the LLVM arena addresses are both fixed for the lifetime of one process. The script is wired into the integration CI job.
+
+---
+
+## Trap-Floats Lowering — Don't Set `unreachable = true`, and Use `@llvm.trap`
+
+`--trap-floats` replaces every f32/f64 operator with an LLVM-level trap (PVM backend lowers to `Trap`). Two non-obvious traps to avoid in the implementation:
+
+### Trap A: setting `self.unreachable = true` after the float trap
+
+The naive implementation is "emit the trap, set `self.unreachable = true`, push placeholder zeros for the operator's outputs." This is wrong on two counts:
+
+1. **The placeholder zeros are never consumed.** The dead-code skip path at the top of `translate_operator` returns `Ok(())` for every non-control-flow op when `self.unreachable` is true — including any future op that would have consumed those zeros. Pushing them is dead work.
+
+2. **Function-result phis end up with no incoming branches.** The function-end implicit `Block` frame's `End` handler skips the "pop result, branch to merge" path when `self.unreachable` is true. If the only path through the body trapped, the result phi at `fn_return` has zero incoming edges → LLVM verifier rejects the module. The same hazard applies to `if`-arm phis when both arms trap.
+
+The correct lowering: emit `unreachable`, create a fresh `after_float_trap` basic block, position there, pop the operator's inputs from the operand stack, push `i64 0` placeholders for its outputs, **and leave `self.unreachable` alone**. Subsequent ops translate normally into the (provably-dead) block; `End` handlers run their reachable branch and add a placeholder-zero incoming to the merge phi; LLVM's `dce` collapses the unreachable region away. Result: valid IR + correct runtime trap + no special-case handling for trap-floats in any other translator path.
+
+The investigation cost was non-trivial — the broken phi only manifests when both arms of a structured construct trap, which is a rare pattern in the unit tests but common in trap-floats mode (entire float-heavy functions trap on the first const). The integration test `trap_floats_inside_if_arm_compiles` pins this down.
+
+`self.unreachable` keeps its original meaning: "WASM operand-stack-aware dead code following an explicit `unreachable`/`return`/`br` operator." The trap-floats lowering produces *LLVM*-level dead code, not WASM-level dead code, and the two abstractions must not be conflated.
+
+### Trap B: bare `unreachable` is folded by simplifycfg as UB
+
+The first working version emitted only `build_unreachable()` (no `@llvm.trap` call). Tests verified compilation succeeded, but a runtime-execution test caught the real bug: floats inside an `if`-arm vanished. anan-as reported `Status: 0` (clean halt) on the trap path because **LLVM's `simplifycfg` folds branches whose only path leads to `unreachable`** — it treats `unreachable` as "this code is impossible; the condition must steer away from it" and rewrites the conditional branch to always take the other arm. Float-only else-bodies were silently deleted; the JAM ran the then-arm regardless of the condition.
+
+The fix: emit `@llvm.trap()` (a real intrinsic call) followed by `build_unreachable()`. `@llvm.trap` is `noreturn` but **not** UB-on-reach — the optimizer treats it as a side-effecting call and preserves it. The PVM backend gains a dedicated case in `lower_llvm_intrinsic` that emits `Instruction::Trap`. The bare `unreachable` after the call is fine (it's now redundant but lets the verifier see the BB has a terminator).
+
+Detection lesson: a pure compilation test can't catch this. The Rust integration tests all checked "JAM compiles and contains a Trap instruction" — which was true (the entry-header trap is always present). Only running the JAM through anan-as with both branch inputs and asserting `Status: 1` on the trap path exposed the elimination. The bun layer1 test `trap-floats.test.ts` is the regression guard.

--- a/docs/src/trap-floats.md
+++ b/docs/src/trap-floats.md
@@ -39,8 +39,14 @@ The frontend has a small table mapping each f32/f64 operator to its
 `(pop_count, push_count)` stack effect. When `trap_floats` is enabled and a
 float operator is encountered:
 
-1. An LLVM `unreachable` instruction is emitted (which the PVM backend lowers
-   to a `Trap` instruction).
+1. An `@llvm.trap()` intrinsic call is emitted, followed by an LLVM
+   `unreachable` terminator so the basic block is well-formed. The PVM
+   backend's `lower_llvm_intrinsic` lowers `@llvm.trap()` to
+   `Instruction::Trap`. Crucially we cannot use a bare `unreachable` here:
+   `simplifycfg` treats `unreachable` as undefined behaviour and will fold
+   away conditional branches whose only path leads to it, silently deleting
+   float-only if-arms (see `learnings.md` "Trap-Floats Lowering" for the
+   investigation that caught this).
 2. A fresh basic block is created and the IR builder positions there. The
    block has no predecessor edge, so subsequent operators translate into
    provably-dead code that LLVM's `dce` pass removes.

--- a/docs/src/trap-floats.md
+++ b/docs/src/trap-floats.md
@@ -1,0 +1,100 @@
+# Trap Floats Mode
+
+PVM has no floating-point instructions. By default, the compiler rejects any
+f32/f64 operator with a `FloatNotSupported` or `Unsupported(...)` error,
+making it impossible to compile any WASM module that touches floats — even if
+the float code path is never exercised at runtime.
+
+The `--trap-floats` flag (or `CompileOptions::trap_floats = true` in the
+library API) changes this behavior: every f32/f64 operator is replaced with a
+runtime PVM `trap` instruction. Compilation completes; if execution ever
+reaches one of those operators, the program traps deterministically.
+
+## When to use it
+
+- **Triage**: a real-world WASM module fails on its first float op. Use
+  `--trap-floats` to push past the wall and discover what *other* unsupported
+  features the module uses (data segments, exotic SIMD ops, etc.). The
+  diagnostic upgrade in the same release prints the failing function and op
+  offset for any remaining errors, so a single re-compile usually pinpoints
+  every blocker.
+
+- **Compiling integer-only entry paths in float-heavy modules**: if the float
+  code is dead under your inputs (e.g. error-formatting helpers that you'll
+  never trigger), `--trap-floats` makes the rest of the module shippable.
+
+## When *not* to use it
+
+- **Production builds where any float computation is reachable.** The trap is
+  silent at compile time and only fires at runtime. If you're not certain the
+  float code is dead, you'll ship a JAM that traps on real input.
+
+- **Soft-float emulation.** `--trap-floats` does *not* emulate IEEE 754
+  arithmetic. There is currently no plan to add soft-float support; if your
+  module needs working floats, PVM is the wrong target.
+
+## How it works
+
+The frontend has a small table mapping each f32/f64 operator to its
+`(pop_count, push_count)` stack effect. When `trap_floats` is enabled and a
+float operator is encountered:
+
+1. An LLVM `unreachable` instruction is emitted (which the PVM backend lowers
+   to a `Trap` instruction).
+2. A fresh basic block is created and the IR builder positions there. The
+   block has no predecessor edge, so subsequent operators translate into
+   provably-dead code that LLVM's `dce` pass removes.
+3. The translator pops `pop_count` entries from the operand stack and pushes
+   `push_count` zero placeholders, keeping the operand stack shape consistent
+   with the WASM validator's view of the rest of the function.
+
+The translator does **not** set its `unreachable` flag. That flag is reserved
+for WASM-level dead-code skipping (driven by `unreachable`/`return`/`br`); a
+float trap is structurally still "live code" from the WASM operand-stack
+perspective — the placeholders flow into subsequent ops normally, even though
+LLVM will optimise them away.
+
+This approach handles the tricky corner cases:
+
+- A float op inside one arm of an `if` traps that arm; the merge block's phi
+  still receives an incoming edge from the after-trap block (with a
+  placeholder zero), keeping the IR valid.
+- A function that returns f64 still produces a function-end phi with at least
+  one incoming branch (the placeholder zero pushed after the trap).
+- Calls between functions with float signatures keep working because the
+  i64-uniform calling convention treats every parameter and return value as
+  i64 anyway — both caller and callee just pass placeholders that nobody
+  reads before the trap fires.
+
+## Float operators covered
+
+All MVP f32/f64 operators (≈60 ops) are covered:
+
+- Constants: `f32.const`, `f64.const`
+- Loads / stores: `f{32,64}.{load,store}`
+- Unary: `abs`, `neg`, `sqrt`, `ceil`, `floor`, `trunc`, `nearest`
+- Binary: `add`, `sub`, `mul`, `div`, `min`, `max`, `copysign`
+- Comparisons: `eq`, `ne`, `lt`, `gt`, `le`, `ge` (return i32)
+- Conversions: every variant of `i{32,64}.trunc[_sat]_f{32,64}_{s,u}`,
+  `f{32,64}.convert_i{32,64}_{s,u}`, `f32.demote_f64`, `f64.promote_f32`,
+  `{i,f}{32,64}.reinterpret_{f,i}{32,64}`
+
+SIMD float operators (`f32x4.*`, `f64x2.*`) are *not* in this set; modules
+using SIMD will still fail with the SIMD operator's own unsupported error.
+
+## Example
+
+```bash
+# Default: compilation fails on the first float op.
+$ wasm-pvm compile runtime.wasm -o runtime.jam
+Error: Compilation failed
+
+Caused by:
+    Unsupported WASM feature: F64Load { memarg: ... } (in function #42 'compute_score' at byte offset 0x1a3)
+
+# With --trap-floats: compiles, traps at runtime if compute_score is called.
+$ wasm-pvm compile runtime.wasm -o runtime.jam --trap-floats
+wasm-pvm v0.8.0
+...
+Compiled in 312ms
+```

--- a/examples/polkadot/README.md
+++ b/examples/polkadot/README.md
@@ -1,0 +1,32 @@
+# Polkadot Runtime Triage
+
+This directory exists for batch-compiling Polkadot fellowship runtime WASM
+binaries through the `wasm-pvm` compiler. The runtimes themselves are not
+checked in — drop your `*.wasm` files alongside `compile.sh` before running.
+
+## Usage
+
+```bash
+# Default: compilation fails on the first unsupported operator. The new
+# diagnostic prints the offending function and byte offset.
+./compile.sh
+
+# Trap-floats mode: convert every f32/f64 operator to a runtime trap so
+# compilation can finish. Useful for finding what *other* unsupported
+# features each runtime uses past the float wall.
+TRAP_FLOATS=1 ./compile.sh
+
+# Pass arbitrary extra flags to wasm-pvm.
+COMPILE_ARGS="--no-inline --max-memory 32" ./compile.sh
+```
+
+Compiled `.jam` files and per-runtime logs land in `examples/polkadot/dist/`.
+
+## Results
+
+This table is intentionally blank in the upstream repo. Re-run the script
+locally with whichever runtime set you care about and paste the output here:
+
+| Runtime | Default | `--trap-floats` | First unsupported feature |
+|---------|---------|-----------------|---------------------------|
+| _example_ | FAIL @ `compute_score` 0x1a3 (`F64Load`) | OK | n/a |

--- a/examples/polkadot/compile.sh
+++ b/examples/polkadot/compile.sh
@@ -77,4 +77,5 @@ if [[ ${fail} -gt 0 ]]; then
     for f in "${failures[@]}"; do
         echo "  ${f}  → see ${OUT_DIR}/${f}.log"
     done
+    exit 1
 fi

--- a/examples/polkadot/compile.sh
+++ b/examples/polkadot/compile.sh
@@ -54,6 +54,10 @@ for wasm in "${WASM_FILES[@]}"; do
     name="$(basename "${wasm}" .wasm)"
     out="${OUT_DIR}/${name}.jam"
     log="${OUT_DIR}/${name}.log"
+    # Clear any stale .jam from a previous run so a failure here can't leave
+    # a previously-successful artifact behind for downstream tooling to pick
+    # up while the summary says FAIL.
+    rm -f "${out}"
 
     printf '%-40s ' "${name}"
     if "${CLI_BIN}" compile "${wasm}" -o "${out}" "${EXTRA_FLAGS[@]}" >"${log}" 2>&1; then
@@ -61,6 +65,9 @@ for wasm in "${WASM_FILES[@]}"; do
         printf 'OK   %s bytes\n' "${size}"
         ok=$((ok + 1))
     else
+        # The CLI may have written a partial file before erroring; remove it
+        # so there's no chance of a corrupt JAM masquerading as valid output.
+        rm -f "${out}"
         # Surface the most informative line from the error: the new diagnostic
         # wraps unsupported-feature errors with function name + byte offset.
         first_err=$(grep -m 1 -E 'Unsupported|Float|in function' "${log}" || true)

--- a/examples/polkadot/compile.sh
+++ b/examples/polkadot/compile.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Compile every *.wasm file in this directory to PVM (.jam), reporting status.
+#
+# Set TRAP_FLOATS=1 to pass --trap-floats and convert f32/f64 ops into runtime
+# traps. Useful for triaging which modules use floats vs. which use other
+# unsupported features.
+#
+# This directory ships without WASM binaries — drop your own runtime *.wasm
+# files alongside this script before running.
+#
+# Usage:
+#   ./compile.sh              # default mode (floats are a hard error)
+#   TRAP_FLOATS=1 ./compile.sh # convert float ops to runtime traps
+#   COMPILE_ARGS="--no-inline" ./compile.sh   # extra flags forwarded to wasm-pvm
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)"
+
+CLI_BIN="${REPO_ROOT}/target/release/wasm-pvm"
+if [[ ! -x "${CLI_BIN}" ]]; then
+    echo "Building release binary..."
+    (cd "${REPO_ROOT}" && cargo build --release -p wasm-pvm-cli) || exit $?
+fi
+
+EXTRA_FLAGS=()
+if [[ "${TRAP_FLOATS:-0}" == "1" ]]; then
+    EXTRA_FLAGS+=("--trap-floats")
+fi
+if [[ -n "${COMPILE_ARGS:-}" ]]; then
+    # shellcheck disable=SC2206
+    EXTRA_FLAGS+=(${COMPILE_ARGS})
+fi
+
+OUT_DIR="${SCRIPT_DIR}/dist"
+mkdir -p "${OUT_DIR}"
+
+shopt -s nullglob
+WASM_FILES=("${SCRIPT_DIR}"/*.wasm)
+shopt -u nullglob
+
+if [[ ${#WASM_FILES[@]} -eq 0 ]]; then
+    echo "No *.wasm files found in ${SCRIPT_DIR}." >&2
+    echo "Drop runtime WASM binaries here and re-run." >&2
+    exit 1
+fi
+
+ok=0
+fail=0
+declare -a failures=()
+
+for wasm in "${WASM_FILES[@]}"; do
+    name="$(basename "${wasm}" .wasm)"
+    out="${OUT_DIR}/${name}.jam"
+    log="${OUT_DIR}/${name}.log"
+
+    printf '%-40s ' "${name}"
+    if "${CLI_BIN}" compile "${wasm}" -o "${out}" "${EXTRA_FLAGS[@]}" >"${log}" 2>&1; then
+        size=$(wc -c <"${out}")
+        printf 'OK   %s bytes\n' "${size}"
+        ok=$((ok + 1))
+    else
+        # Surface the most informative line from the error: the new diagnostic
+        # wraps unsupported-feature errors with function name + byte offset.
+        first_err=$(grep -m 1 -E 'Unsupported|Float|in function' "${log}" || true)
+        printf 'FAIL %s\n' "${first_err}"
+        failures+=("${name}")
+        fail=$((fail + 1))
+    fi
+done
+
+echo
+echo "Summary: ${ok} compiled, ${fail} failed"
+if [[ ${fail} -gt 0 ]]; then
+    echo "Failures:"
+    for f in "${failures[@]}"; do
+        echo "  ${f}  → see ${OUT_DIR}/${f}.log"
+    done
+fi

--- a/tests/fixtures/wat-trap-floats/float-trap.wat
+++ b/tests/fixtures/wat-trap-floats/float-trap.wat
@@ -1,0 +1,35 @@
+;; Test fixture for `--trap-floats` mode.
+;;
+;; Default compile: must FAIL (`f64.add` is unsupported).
+;; --trap-floats compile: must SUCCEED. At runtime, the function takes a
+;; one-byte input. When the input is zero the function returns normally
+;; (no float op executed); when non-zero it falls into the float branch and
+;; traps deterministically.
+;;
+;; This fixture lives outside `tests/fixtures/wat/` (which the build
+;; orchestrator auto-compiles with default flags) so we can drive its
+;; compilation manually from `layer1/trap-floats.test.ts`.
+(module
+  (memory (export "memory") 1)
+  (func (export "main") (param $args_ptr i32) (param $args_len i32) (result i64)
+    ;; Read first byte of args. Zero → safe path; non-zero → float trap path.
+    (local $flag i32)
+    local.get $args_ptr
+    i32.load8_u
+    local.set $flag
+
+    local.get $flag
+    i32.eqz
+    if (result i64)
+      ;; Safe path: return ptr=0, len=4 (no float op encountered).
+      i64.const 17179869184
+    else
+      ;; Trap path: any float op fires the trap before this branch returns.
+      f64.const 1.0
+      f64.const 2.0
+      f64.add
+      drop
+      i64.const 17179869184
+    end
+  )
+)

--- a/tests/layer1/trap-floats.test.ts
+++ b/tests/layer1/trap-floats.test.ts
@@ -1,0 +1,110 @@
+/**
+ * End-to-end test for `--trap-floats` mode and the location-aware diagnostic.
+ *
+ * Drives the `wasm-pvm` CLI directly (instead of going through `defineSuite`)
+ * because:
+ * 1. The default build of the float fixture is *expected* to fail; auto-
+ *    compilation by `build.ts` would block the whole test suite.
+ * 2. We need to assert on the CLI's stderr to verify the new diagnostic
+ *    surface (function name + byte offset).
+ *
+ * Fixture lives in `tests/fixtures/wat-trap-floats/` (outside the auto-built
+ * `tests/fixtures/wat/` tree).
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { execFileSync, execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  ANAN_AS_CLI,
+  CLI_BINARY,
+  FIXTURES_DIR,
+  JAM_DIR,
+  PROJECT_ROOT,
+} from "../helpers/paths";
+
+const WAT_PATH = path.join(FIXTURES_DIR, "wat-trap-floats/float-trap.wat");
+const JAM_PATH = path.join(JAM_DIR, "float-trap.jam");
+
+// Ensure the JAM dir exists; build.ts normally creates it but we run before
+// the orchestrator may have touched the trap-floats subtree.
+beforeAll(() => {
+  fs.mkdirSync(JAM_DIR, { recursive: true });
+  // Always start clean so a stale JAM from a prior run can't make a failing
+  // compile look like a success.
+  if (fs.existsSync(JAM_PATH)) fs.unlinkSync(JAM_PATH);
+});
+
+describe("trap-floats CLI behavior", () => {
+  test("default mode rejects f64.add with location diagnostic", () => {
+    let exitCode = 0;
+    let stderr = "";
+    try {
+      execFileSync(CLI_BINARY, ["compile", WAT_PATH, "-o", JAM_PATH], {
+        cwd: PROJECT_ROOT,
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (err: any) {
+      exitCode = err.status ?? 1;
+      stderr = (err.stderr ?? "").toString();
+    }
+
+    expect(exitCode).not.toBe(0);
+
+    // The new diagnostic must mention the function name and a byte offset.
+    expect(stderr).toContain("'main'");
+    expect(stderr).toMatch(/byte offset 0x[0-9a-f]+/);
+
+    // And it should still classify the failure as an unsupported feature.
+    // anyhow's `Caused by:` chain shows both the wrapper and the inner error.
+    expect(stderr).toContain("Unsupported");
+
+    // No JAM file should exist after a failed compile.
+    expect(fs.existsSync(JAM_PATH)).toBe(false);
+  });
+
+  test("--trap-floats compiles and writes a JAM", () => {
+    execFileSync(
+      CLI_BINARY,
+      ["compile", WAT_PATH, "-o", JAM_PATH, "--trap-floats"],
+      {
+        cwd: PROJECT_ROOT,
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+    expect(fs.existsSync(JAM_PATH)).toBe(true);
+    expect(fs.statSync(JAM_PATH).size).toBeGreaterThan(0);
+  });
+
+  test("compiled JAM runs cleanly when the float branch is skipped", () => {
+    // First byte of args = 0 → safe path → no float op executed.
+    const cmd = `node ${ANAN_AS_CLI} run --spi --no-logs --gas=100000000 ${JAM_PATH} 0x00`;
+    const stdout = execSync(cmd, {
+      cwd: PROJECT_ROOT,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    // anan-as prints `Status: 0` on clean halt, `Status: <non-zero>` on trap
+    // or panic. The safe path must show clean status and a non-empty Result.
+    expect(stdout).toMatch(/Status:\s*0\b/);
+    expect(stdout).toMatch(/Result:\s*\[0x[0-9a-fA-F]+\]/);
+  });
+
+  test("compiled JAM traps when the float branch is taken", () => {
+    // First byte of args = 1 → trap path → @llvm.trap → PVM Trap instruction.
+    const cmd = `node ${ANAN_AS_CLI} run --spi --no-logs --gas=100000000 ${JAM_PATH} 0x01`;
+    const stdout = execSync(cmd, {
+      cwd: PROJECT_ROOT,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    // anan-as reports a non-zero PVM `Status:` on trap and emits an empty
+    // `Result: [0x]` (no bytes returned because execution didn't reach the
+    // ptr/len pack). Both signals together pin down the trap behavior.
+    expect(stdout).toMatch(/Status:\s*[1-9]/);
+    expect(stdout).toContain("Result: [0x]");
+  });
+});

--- a/tests/layer1/trap-floats.test.ts
+++ b/tests/layer1/trap-floats.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { describe, test, expect, beforeAll } from "bun:test";
-import { execFileSync, execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import {
@@ -79,10 +79,21 @@ describe("trap-floats CLI behavior", () => {
     expect(fs.statSync(JAM_PATH).size).toBeGreaterThan(0);
   });
 
+  // Shared anan-as runner args: any difference between safe/trap runs is the
+  // final hex argument byte.
+  const ananAsArgs = (hexArg: string) => [
+    ANAN_AS_CLI,
+    "run",
+    "--spi",
+    "--no-logs",
+    "--gas=100000000",
+    JAM_PATH,
+    hexArg,
+  ];
+
   test("compiled JAM runs cleanly when the float branch is skipped", () => {
     // First byte of args = 0 → safe path → no float op executed.
-    const cmd = `node ${ANAN_AS_CLI} run --spi --no-logs --gas=100000000 ${JAM_PATH} 0x00`;
-    const stdout = execSync(cmd, {
+    const stdout = execFileSync("node", ananAsArgs("0x00"), {
       cwd: PROJECT_ROOT,
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],
@@ -95,8 +106,7 @@ describe("trap-floats CLI behavior", () => {
 
   test("compiled JAM traps when the float branch is taken", () => {
     // First byte of args = 1 → trap path → @llvm.trap → PVM Trap instruction.
-    const cmd = `node ${ANAN_AS_CLI} run --spi --no-logs --gas=100000000 ${JAM_PATH} 0x01`;
-    const stdout = execSync(cmd, {
+    const stdout = execFileSync("node", ananAsArgs("0x01"), {
       cwd: PROJECT_ROOT,
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],

--- a/tests/layer1/trap-floats.test.ts
+++ b/tests/layer1/trap-floats.test.ts
@@ -12,7 +12,7 @@
  * `tests/fixtures/wat/` tree).
  */
 
-import { describe, test, expect, beforeAll } from "bun:test";
+import { describe, test, expect, beforeAll, beforeEach } from "bun:test";
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
@@ -31,8 +31,12 @@ const JAM_PATH = path.join(JAM_DIR, "float-trap.jam");
 // the orchestrator may have touched the trap-floats subtree.
 beforeAll(() => {
   fs.mkdirSync(JAM_DIR, { recursive: true });
-  // Always start clean so a stale JAM from a prior run can't make a failing
-  // compile look like a success.
+});
+
+// Reset per-test so any single test in this file is independent of execution
+// order. The compile-failure test expects no JAM; the runtime tests recreate
+// it via `compileTrapFloatsJam()`.
+beforeEach(() => {
   if (fs.existsSync(JAM_PATH)) fs.unlinkSync(JAM_PATH);
 });
 
@@ -65,7 +69,12 @@ describe("trap-floats CLI behavior", () => {
     expect(fs.existsSync(JAM_PATH)).toBe(false);
   });
 
-  test("--trap-floats compiles and writes a JAM", () => {
+  // Compile the trap-floats JAM. Each test that needs the JAM calls this
+  // first so the runtime tests don't silently depend on the compile test
+  // having executed earlier (single-test runs and reordered runners would
+  // otherwise fail on missing setup rather than on actual trap behavior).
+  // Compilation is fast enough (~5ms) that the redundancy is fine.
+  const compileTrapFloatsJam = () =>
     execFileSync(
       CLI_BINARY,
       ["compile", WAT_PATH, "-o", JAM_PATH, "--trap-floats"],
@@ -75,9 +84,6 @@ describe("trap-floats CLI behavior", () => {
         stdio: ["pipe", "pipe", "pipe"],
       },
     );
-    expect(fs.existsSync(JAM_PATH)).toBe(true);
-    expect(fs.statSync(JAM_PATH).size).toBeGreaterThan(0);
-  });
 
   // Shared anan-as runner args: any difference between safe/trap runs is the
   // final hex argument byte.
@@ -91,7 +97,14 @@ describe("trap-floats CLI behavior", () => {
     hexArg,
   ];
 
+  test("--trap-floats compiles and writes a JAM", () => {
+    compileTrapFloatsJam();
+    expect(fs.existsSync(JAM_PATH)).toBe(true);
+    expect(fs.statSync(JAM_PATH).size).toBeGreaterThan(0);
+  });
+
   test("compiled JAM runs cleanly when the float branch is skipped", () => {
+    compileTrapFloatsJam();
     // First byte of args = 0 → safe path → no float op executed.
     const stdout = execFileSync("node", ananAsArgs("0x00"), {
       cwd: PROJECT_ROOT,
@@ -105,6 +118,7 @@ describe("trap-floats CLI behavior", () => {
   });
 
   test("compiled JAM traps when the float branch is taken", () => {
+    compileTrapFloatsJam();
     // First byte of args = 1 → trap path → @llvm.trap → PVM Trap instruction.
     const stdout = execFileSync("node", ananAsArgs("0x01"), {
       cwd: PROJECT_ROOT,


### PR DESCRIPTION
## Summary

PVM has no floats, so the compiler currently rejects any f32/f64 op outright. Two changes here unblock triaging real-world WASM modules (Polkadot fellowship runtimes prompted this):

- **`Error::Located { func_idx, func_name, op_offset, source }`** wraps every error from the WASM operator dispatcher with the function index, display name, and operator byte offset. Names come from the WASM \`name\` custom section, falling back to the export name, then \`wasm_func_<idx>\`. Surfaces in error display:
  ```
  Unsupported WASM feature: F64Const { ... } (in function #42 'compute_score' at byte offset 0x1a3)
  ```

- **`--trap-floats`** flag (`CompileOptions.trap_floats`) replaces every f32/f64 operator (~60 MVP ops covered) with a runtime trap so compilation can finish past the float wall. JAMs run normally if execution never reaches a float op; otherwise they trap deterministically.

The trap-floats lowering had two non-obvious pitfalls — both documented in `docs/src/learnings.md`:
- Setting `self.unreachable = true` after the trap leaves function-result phis without an incoming branch (invalid LLVM IR when both arms of a conditional trap)
- Bare LLVM `unreachable` is folded by `simplifycfg` as UB, silently deleting float-only if-arms. Fixed by emitting `@llvm.trap()` (preserved as a `noreturn` side-effect) plus `unreachable`. Backend gains a `llvm.trap → Instruction::Trap` lowering.

`examples/polkadot/` ships a skeleton (`compile.sh` + README) for batch-compiling runtime binaries; the directory is empty by design — drop `*.wasm` files in to use it.

Follow-up issues for deliberate scope cuts: #208 (backend errors should also carry location context), #209 (`CompileStats` should use friendly function names).

## Test plan

- [x] `cargo test` — 375 passed (was 366; +9 in `crates/wasm-pvm/tests/float_handling.rs`)
- [x] `cd tests && bun run test` — 484 passed (was 480; +4 in `tests/layer1/trap-floats.test.ts` covering CLI failure diagnostic, CLI success with `--trap-floats`, runtime clean-halt, runtime trap)
- [x] `cargo clippy -- -D warnings` clean from this diff
- [x] `cargo fmt --check` clean
- [x] Pre-push hook (full integration suite) green
- [x] CLI smoke tested in both modes against a hand-written WAT
- [ ] Polkadot runtime triage — needs binaries the user supplies; out of scope here

## Benchmarks

Per `AGENTS.md` PR policy: `--trap-floats` defaults to `false`, and the diagnostics wrapper only fires on the error path, so no JAM size or gas numbers should change. I have not run `./tests/utils/benchmark.sh` for this PR — happy to run it on request if you want the no-op result confirmed in the PR body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)