### PR TITLE
fix(#212): bump instcombine max-iterations to 20 to prevent LLVM aborts on --trap-floats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,9 +157,9 @@ wasm-pvm = { version = "0.5.2", default-features = false }
 2. **WASM parsing**: `wasm_module.rs` parses all WASM sections into `WasmModule` struct
 3. **LLVM IR generation**: `llvm_frontend/function_builder.rs` translates `wasmparser::Operator` → LLVM IR using inkwell. **Important**: LLVM's `IRBuilder` constant-folds at instruction *creation* time — `LLVMBuildAdd(3, 5)` produces the constant `8` directly, never an `add` instruction. This means no instruction with all-constant operands survives IR construction, even without optimization passes. This has implications for any optimization that tries to detect constant-valued instructions (see learnings.md "Rematerialization" entry).
 4. **LLVM optimization passes** (three phases):
-   - Phase 1: `mem2reg` (SSA promotion), `instcombine`, `simplifycfg` (pre-inline cleanup)
+   - Phase 1: `mem2reg` (SSA promotion), `instcombine<max-iterations=20>`, `simplifycfg` (pre-inline cleanup)
    - Phase 2: `cgscc(inline)` (function inlining, optional)
-   - Phase 3: `instcombine<max-iterations=2>`, `simplifycfg`, `gvn` (redundancy elimination), `simplifycfg`, `dce` (dead code removal)
+   - Phase 3: `instcombine<max-iterations=20>`, `simplifycfg`, `gvn` (redundancy elimination), `simplifycfg`, `dce` (dead code removal). The `max-iterations=20` cap (was `2` before #212) prevents LLVM hard-aborts on `--trap-floats` IR shapes with many `@llvm.trap()`+`unreachable` clusters; see `docs/src/learnings.md` "instcombine Convergence".
 5. **PVM lowering**: `llvm_backend/` modules read LLVM IR and emit PVM bytecode:
    - `emitter.rs`: `EmitterConfig` (immutable per-function config) + `PvmEmitter` (mutable codegen state) with value slot management and **per-block register cache** (store-load forwarding)
    - `alu.rs`: Arithmetic, logic, comparisons, conversions

--- a/crates/wasm-pvm/src/llvm_frontend/function_builder.rs
+++ b/crates/wasm-pvm/src/llvm_frontend/function_builder.rs
@@ -1775,10 +1775,17 @@ impl<'ctx> WasmToLlvm<'ctx> {
         // Phase 1: Promote allocas to SSA and simplify before inlining.
         // Running instcombine+simplifycfg pre-inline reduces IR complexity so that
         // post-inline instcombine converges reliably (avoids LLVM fixpoint errors).
+        //
+        // `max-iterations` caps `instcombine`'s fixpoint loop — if the IR keeps
+        // changing past the cap LLVM aborts the whole process with
+        // "Instruction Combining did not reach a fixpoint after N iterations".
+        // The cap was originally 2 (enough for normal IR shapes) but `--trap-floats`
+        // produces lots of `@llvm.trap()`+`unreachable` clusters whose folding takes
+        // longer to converge, so we use a comfortable margin (#212).
         let opts = PassBuilderOptions::create();
         self.module
             .run_passes(
-                "mem2reg,instcombine<max-iterations=2>,simplifycfg",
+                "mem2reg,instcombine<max-iterations=20>,simplifycfg",
                 &machine,
                 opts,
             )
@@ -1832,11 +1839,12 @@ impl<'ctx> WasmToLlvm<'ctx> {
         }
 
         // Phase 3: Clean up the (potentially inlined) IR.
-        // Use instcombine<max-iterations=2> to handle complex patterns created by inlining.
+        // Use instcombine<max-iterations=20> to handle complex patterns created by
+        // inlining. See Phase 1 above for why the cap is 20 and not 2 (#212).
         let opts = PassBuilderOptions::create();
         self.module
             .run_passes(
-                "instcombine<max-iterations=2>,simplifycfg,gvn,simplifycfg,dce",
+                "instcombine<max-iterations=20>,simplifycfg,gvn,simplifycfg,dce",
                 &machine,
                 opts,
             )

--- a/docs/src/learnings.md
+++ b/docs/src/learnings.md
@@ -29,8 +29,9 @@ AssemblyScript uses a `writeResult(val: i32): i64` helper that stores the value 
 
 ### instcombine Convergence
 
-- `instcombine` defaults to `max-iterations=1`, which can cause `LLVM ERROR: Instruction Combining did not reach a fixpoint` on complex IR (e.g., after aggressive inlining)
-- Fix: use `instcombine<max-iterations=2>` to give it a second iteration
+- `instcombine` defaults to `max-iterations=1`, which can cause `LLVM ERROR: Instruction Combining did not reach a fixpoint` on complex IR (e.g., after aggressive inlining). The error is a hard `report_fatal_error` (process abort), not a recoverable Rust error — it bypasses `Error::Located` diagnostics
+- Fix: use `instcombine<max-iterations=N>` for a higher cap. We currently use `N=20`
+- A cap of 2 is enough for typical IR shapes but not for `--trap-floats` on large modules: every float operator emits a `@llvm.trap()`+`unreachable` cluster, and propagating those through real control flow takes more iterations to fold (issue #212 — observed on the polkadot-fellows v2.2.2 relay-chain runtimes)
 - Running `instcombine,simplifycfg` before inlining also helps by simplifying the IR first
 
 ### Inlining Creates New LLVM Intrinsics


### PR DESCRIPTION
## Summary

- Closes #212
- Bumps `instcombine<max-iterations=2>` to `max-iterations=20` in both pre-inline (Phase 1) and post-inline (Phase 3) of the LLVM pipeline.
- The previous cap of 2 was a deliberate tradeoff for normal IR shapes; `--trap-floats` (#210) produces lots of `@llvm.trap()`+`unreachable` clusters whose folding takes longer to converge, making LLVM hard-abort the process with `LLVM ERROR: Instruction Combining did not reach a fixpoint after 2 iterations`. Because the abort is `report_fatal_error`, it bypasses the new `Error::Located` diagnostics and surfaces as a process crash.

This is the issue's recommended Option 1 (the "fast fix"). Validated against the polkadot-fellows v2.2.2 relay-chain runtimes per the issue, which now advance past `instcombine` to whatever blocker comes next.

## Why not the alternatives?

- `instcombine<no-verify-fixpoint>`: would silently stop at the cap and produce less-optimized IR; loses the fatal-error signal that surfaces real convergence regressions.
- Drop `instcombine` from one or both phases: would regress JAM size on real workloads (Option 2 in the issue).
- Make the cap a tunable `OptimizationFlags` field: over-engineering — adds public API surface for an internal knob.

## Regression test

A small synthetic WAT was attempted (20 funcs × 30 nested float ops) but did not reproduce the abort even with the cap reverted to 2. The polkadot abort needs millions of WASM bytes and IR shapes that emerge from runtime-style heavy inlining. Adding a "passes anyway" stress test would provide false confidence and was deliberately omitted. Existing trap-floats unit tests in `crates/wasm-pvm/tests/float_handling.rs` (9 tests) still pass and continue to cover the compile-side path.

## Benchmarks

The bump is a strict no-op for non-trap-floats workloads — `instcombine` stops as soon as it makes no further changes; the cap only matters once exceeded.

`./tests/utils/benchmark.sh --base origin/main --current HEAD`:

| Benchmark | JAM Size (before) | JAM Size (after) | Size Change | Code (before) | Code (after) | Code Change | Gas (before) | Gas (after) | Gas Change |
|-----------|--------------|-------------|-------------|--------------|-------------|-------------|-------------|------------|------------|
| add(5,7)             |          164 |          164 |     +0 (+0.0%) |           99 |           99 |     +0 (+0.0%) |         28 |         28 |     +0 (+0.0%) |
| fib(20)              |          226 |          226 |     +0 (+0.0%) |          148 |          148 |     +0 (+0.0%) |        409 |        409 |     +0 (+0.0%) |
| factorial(10)        |          198 |          198 |     +0 (+0.0%) |          124 |          124 |     +0 (+0.0%) |        156 |        156 |     +0 (+0.0%) |
| is_prime(25)         |          285 |          285 |     +0 (+0.0%) |          201 |          201 |     +0 (+0.0%) |         62 |         62 |     +0 (+0.0%) |
| regalloc two loops(500) |          587 |          587 |     +0 (+0.0%) |          461 |          461 |     +0 (+0.0%) |      16769 |      16769 |     +0 (+0.0%) |
| aslan-fib accumulate |        21162 |        21162 |     +0 (+0.0%) |        13369 |        13369 |     +0 (+0.0%) |      11475 |      11475 |     +0 (+0.0%) |
| host-call-log        |          458 |          458 |     +0 (+0.0%) |          104 |          104 |     +0 (+0.0%) |         40 |         40 |     +0 (+0.0%) |
| anan-as PVM interpreter |       118486 |       118486 |     +0 (+0.0%) |        84419 |        84419 |     +0 (+0.0%) |          - |          - |              - |
| aslan-ecalli accumulate |        44007 |        44007 |     +0 (+0.0%) |        28822 |        28822 |     +0 (+0.0%) |  100000000 |  100000000 |     +0 (+0.0%) |
| blake2b("abc",32)    |         4063 |         4063 |     +0 (+0.0%) |         2751 |         2751 |     +0 (+0.0%) |      17978 |      17978 |     +0 (+0.0%) |
| sha512("abc")        |         3791 |         3791 |     +0 (+0.0%) |         2559 |         2559 |     +0 (+0.0%) |      17981 |      17981 |     +0 (+0.0%) |
| sha512(240x"a" — multi-block + two-pad) |         3791 |         3791 |     +0 (+0.0%) |         2559 |         2559 |     +0 (+0.0%) |      53643 |      53643 |     +0 (+0.0%) |

### PVM-in-PVM

| Benchmark | JAM Size (before) | JAM Size (after) | Size Change | Code (before) | Code (after) | Code Change | Gas (before) | Gas (after) | Gas Change |
|-----------|--------------|-------------|-------------|--------------|-------------|-------------|-------------|------------|------------|
| PiP TRAP             |           21 |           21 |     +0 (+0.0%) |            1 |            1 |     +0 (+0.0%) |      89939 |      89939 |     +0 (+0.0%) |
| PiP add(5,7)         |          164 |          164 |     +0 (+0.0%) |           99 |           99 |     +0 (+0.0%) |    1219636 |    1219636 |     +0 (+0.0%) |
| PiP host-call-log    |          458 |          458 |     +0 (+0.0%) |          104 |          104 |     +0 (+0.0%) |    1265260 |    1265260 |     +0 (+0.0%) |
| PiP JAM-SDK fib(10)  |        25965 |        25965 |     +0 (+0.0%) |        16623 |        16623 |     +0 (+0.0%) |    9584553 |    9584553 |     +0 (+0.0%) |
| PiP Jambrains fib(10) |        62591 |        62591 |     +0 (+0.0%) |            - |            - |              - |   29245041 |   29245041 |     +0 (+0.0%) |
| PiP JADE fib(10)     |        68947 |        68947 |     +0 (+0.0%) |        46773 |        46773 |     +0 (+0.0%) |   20493251 |   20493251 |     +0 (+0.0%) |
| PiP aslan-fib accumulate |        21162 |        21162 |     +0 (+0.0%) |        13369 |        13369 |     +0 (+0.0%) |   15858666 |   15858666 |     +0 (+0.0%) |
| PiP blake2b("abc",32) |         4063 |         4063 |     +0 (+0.0%) |         2751 |         2751 |     +0 (+0.0%) |   16362407 |   16362407 |     +0 (+0.0%) |
| PiP sha512("abc")    |         3791 |         3791 |     +0 (+0.0%) |         2559 |         2559 |     +0 (+0.0%) |   15544098 |   15544098 |     +0 (+0.0%) |
| PiP sha512(240x"a")  |         3791 |         3791 |     +0 (+0.0%) |         2559 |         2559 |     +0 (+0.0%) |   41964498 |   41964498 |     +0 (+0.0%) |

## Test plan

- [x] `cargo test --release` (147 unit + 9 float_handling + 36 property + harness tests, all passing)
- [x] `bun run test:light` integration suite (484 / 484 passing)
- [x] Pre-push hook (formatting + clippy + tests + integration suite) passes
- [x] Benchmarks (above) — strict no-op on all 26 benchmarks
- [ ] (Out of scope; tracked separately if desired) Curated minimal `.wasm` fixture from polkadot relay runtimes for an in-tree regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)