### PR TITLE
fix: use friendly function names in CompileStats / CLI verbose output

### DIFF
--- a/crates/wasm-pvm/src/translate/mod.rs
+++ b/crates/wasm-pvm/src/translate/mod.rs
@@ -423,9 +423,8 @@ fn compile_via_llvm(module: &WasmModule, options: &CompileOptions) -> Result<Com
             function_offsets[local_func_idx] = func_start_offset;
             all_instructions.push(Instruction::Trap);
             dead_functions_eliminated += 1;
-            let global_func_idx = module.num_imported_funcs as usize + local_func_idx;
             function_stats.push(stats::FunctionStats {
-                name: format!("wasm_func_{global_func_idx}"),
+                name: module.local_function_display_name(local_func_idx),
                 index: local_func_idx,
                 instruction_count: 1,
                 frame_size: 0,
@@ -540,7 +539,7 @@ fn compile_via_llvm(module: &WasmModule, options: &CompileOptions) -> Result<Com
 
         let ls = &translation.lowering_stats;
         function_stats.push(stats::FunctionStats {
-            name: fn_name,
+            name: module.local_function_display_name(local_func_idx),
             index: local_func_idx,
             instruction_count: translation.instructions.len(),
             frame_size: ls.frame_size,

--- a/crates/wasm-pvm/tests/function_names.rs
+++ b/crates/wasm-pvm/tests/function_names.rs
@@ -99,3 +99,37 @@ fn unnamed_unexported_function_uses_synthetic_name() {
         "unnamed/unexported helper should use the synthetic placeholder"
     );
 }
+
+/// Synthetic placeholder must use the *global* function index. With one
+/// import in front, the local helper at `local_idx == 0` should render as
+/// `wasm_func_1`, not `wasm_func_0`. This guards against regressions where
+/// someone wires `local_idx` directly into the placeholder.
+#[test]
+fn unnamed_unexported_function_with_import_uses_global_index_placeholder() {
+    let wat = r#"
+        (module
+            (import "env" "abort" (func))
+            (func (result i32)
+                i32.const 1
+            )
+            (func (export "main") (param i32 i32) (result i64)
+                call 1
+                drop
+                i64.const 17179869184
+            )
+        )
+    "#;
+    let wasm = wat_to_wasm(wat).expect("WAT should parse");
+    let (_program, stats) =
+        compile_with_stats(&wasm, &CompileOptions::default()).expect("compilation should succeed");
+
+    let helper = stats
+        .functions
+        .iter()
+        .find(|f| f.index == 0)
+        .expect("helper function must be present in stats");
+    assert_eq!(
+        helper.name, "wasm_func_1",
+        "synthetic placeholder must use the global index (1 import + 0 local = 1)"
+    );
+}

--- a/crates/wasm-pvm/tests/function_names.rs
+++ b/crates/wasm-pvm/tests/function_names.rs
@@ -1,0 +1,101 @@
+//! Tests for friendly function names in `CompileStats`.
+//!
+//! `FunctionStats.name` should reflect the WASM `name` custom section, with
+//! the export name and synthetic `wasm_func_<global_idx>` placeholder as
+//! fallbacks. This is what the CLI's `--verbose` and `--json` output show.
+
+use wasm_pvm::test_harness::wat_to_wasm;
+use wasm_pvm::{CompileOptions, compile_with_stats};
+
+/// `$identifier` in WAT becomes a name-section entry and should be picked up
+/// by `FunctionStats.name`. Export names are an independent fallback.
+#[test]
+fn name_section_identifier_used_for_function_stats() {
+    let wat = r#"
+        (module
+            (func $helper (result i32)
+                i32.const 7
+            )
+            (func $entry (export "main") (param i32 i32) (result i64)
+                i64.const 17179869184
+            )
+        )
+    "#;
+    let wasm = wat_to_wasm(wat).expect("WAT should parse");
+    let (_program, stats) =
+        compile_with_stats(&wasm, &CompileOptions::default()).expect("compilation should succeed");
+
+    let names: Vec<&str> = stats.functions.iter().map(|f| f.name.as_str()).collect();
+    assert!(
+        names.contains(&"helper"),
+        "expected `helper` in function stats names, got {names:?}"
+    );
+    assert!(
+        names.contains(&"entry"),
+        "expected `entry` (name section wins over export alias `main`), got {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n.starts_with("wasm_func_")),
+        "no synthetic placeholder should leak through when names exist, got {names:?}"
+    );
+}
+
+/// When a function has only an export name (no `$identifier`), the display
+/// name falls back to the export name.
+#[test]
+fn export_name_fallback_when_name_section_empty() {
+    let wat = r#"
+        (module
+            (func (export "main") (param i32 i32) (result i64)
+                i64.const 17179869184
+            )
+        )
+    "#;
+    let wasm = wat_to_wasm(wat).expect("WAT should parse");
+    let (_program, stats) =
+        compile_with_stats(&wasm, &CompileOptions::default()).expect("compilation should succeed");
+
+    let entry = stats
+        .functions
+        .iter()
+        .find(|f| f.is_entry)
+        .expect("entry function must exist");
+    assert_eq!(
+        entry.name, "main",
+        "entry stats should fall back to export name `main`"
+    );
+}
+
+/// Functions with no name and no export still get the synthetic placeholder.
+/// (Hard to construct in pure WAT — every local function generally ends up
+/// either named via `$id` or unnamed and unexported when only referenced
+/// internally.) An unnamed, unexported helper called by an exported entry
+/// exercises the fallback path.
+#[test]
+fn unnamed_unexported_function_uses_synthetic_name() {
+    let wat = r#"
+        (module
+            (func (result i32)
+                i32.const 1
+            )
+            (func (export "main") (param i32 i32) (result i64)
+                call 0
+                drop
+                i64.const 17179869184
+            )
+        )
+    "#;
+    let wasm = wat_to_wasm(wat).expect("WAT should parse");
+    let (_program, stats) =
+        compile_with_stats(&wasm, &CompileOptions::default()).expect("compilation should succeed");
+
+    let helper = stats
+        .functions
+        .iter()
+        .find(|f| f.index == 0)
+        .expect("helper function must be present in stats");
+    assert_eq!(
+        helper.name, "wasm_func_0",
+        "unnamed/unexported helper should use the synthetic placeholder"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #209.

`FunctionStats.name` (used by CLI `--verbose` / `--json` and embedded in `CompileStats`) now resolves through `WasmModule::local_function_display_name(local_idx)` — preferring the WASM `name` custom section, then the export name, then the synthetic `wasm_func_<idx>` placeholder. Previously both call sites in `compile_via_llvm` (live-function path and dead-function path) hardcoded the synthetic placeholder, so AS/Rust modules with rich name sections still rendered as `wasm_func_0`, `wasm_func_1`, … in stats output.

A new test file `crates/wasm-pvm/tests/function_names.rs` covers all three resolution tiers (name-section identifier wins, export-name fallback, synthetic placeholder for unnamed/unexported helpers).

## Benchmarks

Skipped — this PR only changes a metadata string in `FunctionStats` and does not touch codegen, so JAM size and gas usage are unaffected (the `benchmark.sh` script also can't run here because `main` is checked out in another Conductor worktree).

## Test plan

- [x] `cargo test` — all suites pass, plus the 3 new tests in `function_names.rs`
- [x] Pre-push hook (fmt / clippy / unit + integration tests) green
- [x] Manual `wasm-pvm compile … --verbose` smoke test now shows `entry` / `helper` instead of `wasm_func_*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)