### PR TITLE
perf(backend): shrink polkadot PVM output by ~2.7% (4 micro-opts)

### DIFF
--- a/crates/wasm-pvm/src/llvm_backend/alu.rs
+++ b/crates/wasm-pvm/src/llvm_backend/alu.rs
@@ -349,6 +349,59 @@ pub fn lower_binary_arith<'ctx>(
         return Ok(());
     }
 
+    // Non-commutative shift with constant LHS: `const SHIFT x` → *ImmAlt variant.
+    // Useful for the common `1 << x` bitmask idiom and similar patterns where
+    // the shift count is variable but the shifted value is a small constant.
+    if let Some(lhs_const) = try_get_constant(lhs)
+        && i32::try_from(lhs_const).is_ok()
+        && matches!(op, BinaryOp::Shl | BinaryOp::LShr | BinaryOp::AShr)
+    {
+        let imm = lhs_const as i32;
+        let mut rhs_reg = operand_reg(e, rhs, TEMP1);
+        if rhs_reg != TEMP1 && rhs_reg == dst {
+            rhs_reg = TEMP1;
+        }
+        if rhs_reg == TEMP1 {
+            e.load_operand(rhs, TEMP1)?;
+        }
+        let instr = match (op, bits <= 32) {
+            (BinaryOp::Shl, true) => Instruction::ShloLImmAlt32 {
+                dst,
+                src: rhs_reg,
+                value: imm,
+            },
+            (BinaryOp::Shl, false) => Instruction::ShloLImmAlt64 {
+                dst,
+                src: rhs_reg,
+                value: imm,
+            },
+            (BinaryOp::LShr, true) => Instruction::ShloRImmAlt32 {
+                dst,
+                src: rhs_reg,
+                value: imm,
+            },
+            (BinaryOp::LShr, false) => Instruction::ShloRImmAlt64 {
+                dst,
+                src: rhs_reg,
+                value: imm,
+            },
+            (BinaryOp::AShr, true) => Instruction::SharRImmAlt32 {
+                dst,
+                src: rhs_reg,
+                value: imm,
+            },
+            (BinaryOp::AShr, false) => Instruction::SharRImmAlt64 {
+                dst,
+                src: rhs_reg,
+                value: imm,
+            },
+            _ => unreachable!("guarded by matches! above"),
+        };
+        e.emit(instr);
+        e.store_to_slot(slot, dst);
+        return Ok(());
+    }
+
     // Commutative constant-LHS folding: `const op x` → `x op const` for commutative ops.
     // LLVM's instcombine usually canonicalizes constants to RHS, but this helps edge cases
     // and --no-llvm-passes mode.

--- a/crates/wasm-pvm/src/llvm_backend/alu.rs
+++ b/crates/wasm-pvm/src/llvm_backend/alu.rs
@@ -856,24 +856,22 @@ pub fn lower_zext<'ctx>(e: &mut PvmEmitter<'ctx>, instr: InstructionValue<'ctx>)
     let dst = result_reg_or(e, instr, TEMP1);
 
     if from_bits == 32 {
-        // i32 → i64: use load-side coalescing for the shift source.
+        // i32 → i64 zero-extend: `(x << 32) >>u 32`. Use immediate-form
+        // shifts so we don't need a separate `LoadImm 32` instruction or a
+        // dedicated register to hold the shift count.
         let src_reg = operand_reg(e, src, dst);
         if src_reg == dst {
             e.load_operand(src, dst)?;
         }
-        e.emit(Instruction::LoadImm {
-            reg: TEMP2,
+        e.emit(Instruction::ShloLImm64 {
+            dst,
+            src: src_reg,
             value: 32,
         });
-        e.emit(Instruction::ShloL64 {
+        e.emit(Instruction::ShloRImm64 {
             dst,
-            src1: src_reg,
-            src2: TEMP2,
-        });
-        e.emit(Instruction::ShloR64 {
-            dst,
-            src1: dst,
-            src2: TEMP2,
+            src: dst,
+            value: 32,
         });
     } else {
         // i1 → i32/i64 (no-op copy) and other widths: load into dst as before.

--- a/crates/wasm-pvm/src/llvm_backend/intrinsics.rs
+++ b/crates/wasm-pvm/src/llvm_backend/intrinsics.rs
@@ -18,7 +18,7 @@ use crate::pvm::Instruction;
 
 use super::emitter::{
     LoweringContext, PvmEmitter, get_operand, operand_bit_width, operand_reg, result_reg,
-    result_slot, val_key_basic,
+    result_slot, try_get_constant, val_key_basic,
 };
 use super::memory::{
     PvmLoadKind, PvmStoreKind, emit_pvm_data_drop, emit_pvm_load, emit_pvm_memory_copy,
@@ -507,15 +507,49 @@ pub fn lower_llvm_intrinsic<'ctx>(
         if val_key_basic(a) == val_key_basic(b) {
             let dst = result_reg(e, instr);
             let mut a_reg = operand_reg(e, a, TEMP1);
-            let mut amt_reg = operand_reg(e, amt, TEMP2);
             if a_reg != TEMP1 && a_reg == dst {
                 a_reg = TEMP1;
             }
-            if amt_reg != TEMP2 && amt_reg == dst {
-                amt_reg = TEMP2;
-            }
             if a_reg == TEMP1 {
                 e.load_operand(a, TEMP1)?;
+            }
+
+            // Constant rotation amount: use the *Imm variants and drop the
+            // `LoadImm` for the amount + the TEMP2 dependency. PVM has no
+            // `RotLImm*` opcodes, so rewrite `rotl(x, n)` as `rotr(x, bits-n)`
+            // when n is known (the two are equivalent modulo the rotation width).
+            if let Some(amt_const) = try_get_constant(amt) {
+                let masked = (amt_const as u64) & u64::from(bits - 1);
+                let is_rotr = name.contains("fshr");
+                let rotr_amt = if is_rotr {
+                    masked
+                } else {
+                    (u64::from(bits) - masked) & u64::from(bits - 1)
+                };
+                #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+                let rotr_amt_i32 = rotr_amt as i32;
+                let rot = if is_32 {
+                    Instruction::RotRImm32 {
+                        dst,
+                        src: a_reg,
+                        value: rotr_amt_i32,
+                    }
+                } else {
+                    Instruction::RotRImm64 {
+                        dst,
+                        src: a_reg,
+                        value: rotr_amt_i32,
+                    }
+                };
+                e.emit(rot);
+                e.store_to_slot(slot, dst);
+                return Ok(());
+            }
+
+            // Variable rotation amount: use the register-form rotates.
+            let mut amt_reg = operand_reg(e, amt, TEMP2);
+            if amt_reg != TEMP2 && amt_reg == dst {
+                amt_reg = TEMP2;
             }
             if amt_reg == TEMP2 {
                 e.load_operand(amt, TEMP2)?;

--- a/crates/wasm-pvm/src/pvm/peephole.rs
+++ b/crates/wasm-pvm/src/pvm/peephole.rs
@@ -460,17 +460,27 @@ fn optimize_store_then_load(
         }
 
         if l_dst == s_src {
-            // Pure no-op: value already in dst.
+            // Pure no-op: value already in dst. Marking for removal is safe
+            // because `compact_instructions` knows how to remove instructions
+            // (it remaps fixups + labels through `byte_to_idx`).
             keep[i + 1] = false;
         } else {
-            // Replace load with a register-to-register copy. Same byte length
-            // as the smallest LoadIndU64 encoding (2 bytes), so smaller-or-
-            // equal in all cases. The byte-offset recompute inside
-            // `compact_instructions` handles any size change.
-            instructions[i + 1] = Instruction::MoveReg {
+            // Replace load with a register-to-register copy. Both `MoveReg`
+            // and `LoadIndU64` use 2-byte encodings only when the load's
+            // offset is zero (`encode_imm(0)` returns an empty slice). For
+            // any non-zero offset, `LoadIndU64` is 3-6 bytes while `MoveReg`
+            // stays at 2, and `compact_instructions` caches `encoded_lengths`
+            // BEFORE this pass mutates, so a size-shrinking in-place rewrite
+            // would silently leave labels past the rewrite point pointing at
+            // stale byte offsets. Only do the rewrite when encoded sizes
+            // match (the offset == 0 case); skip otherwise.
+            let replacement = Instruction::MoveReg {
                 dst: l_dst,
                 src: s_src,
             };
+            if replacement.encode().len() == instructions[i + 1].encode().len() {
+                instructions[i + 1] = replacement;
+            }
         }
     }
 }

--- a/crates/wasm-pvm/src/pvm/peephole.rs
+++ b/crates/wasm-pvm/src/pvm/peephole.rs
@@ -210,6 +210,24 @@ pub fn optimize(
         return;
     }
 
+    // Run the store/load same-slot peephole FIRST, before any pass that can
+    // change instruction encoded sizes. The pass needs to compare each
+    // load's byte offset against `labels[]` to skip branch targets, and
+    // `labels[]` holds emission-time byte offsets. Both
+    // `optimize_address_calculation` (AddImm fusion may grow/shrink the
+    // combined Load/Store offset) and `optimize_immediate_chains` (value
+    // patches may grow/shrink the immediate) can change instruction sizes
+    // in place, which would desync our recomputed byte offsets from the
+    // (stale) label offsets and silently let us drop a real branch target.
+    //
+    // The peephole itself is size-preserving: removals (`keep[i+1] = false`)
+    // don't change any instruction's encoded length, and the
+    // `LoadIndU64 → MoveReg` rewrite is gated on an exact length match in
+    // `optimize_store_then_load`, so running it here doesn't disturb the
+    // size invariants the later passes rely on.
+    let mut keep = vec![true; len];
+    optimize_store_then_load(instructions, &mut keep, labels);
+
     // 1. Optimize address calculations (fuse AddImm + Load/Store).
     // This updates instructions in-place and doesn't remove any, so fixups are fine.
     optimize_address_calculation(instructions, labels);
@@ -230,7 +248,11 @@ pub fn optimize(
     // 3. Simple peephole patterns (redundant fallthroughs).
     // Mark instructions for removal (true = keep, false = remove).
     let len = instructions.len();
-    let mut keep = vec![true; len];
+    debug_assert_eq!(
+        keep.len(),
+        len,
+        "instruction count must not change between store/load peephole and later passes",
+    );
 
     for i in 0..len {
         if !keep[i] {
@@ -267,24 +289,9 @@ pub fn optimize(
         }
     }
 
-    // 4. New: Fuse LoadImm + AddImm chains and chained AddImm operations.
+    // 4. Fuse LoadImm + AddImm chains and chained AddImm operations.
+    // (Store/load peephole already ran at the top of `optimize()`.)
     optimize_immediate_chains(instructions, &mut keep);
-
-    // 5. Eliminate StoreIndU64 → LoadIndU64 at the same (base, offset).
-    //
-    // After `store_to_slot(dst)` the value at `STACK_PTR + offset` is exactly
-    // what's in the source register. When a following `LoadIndU64` reads it
-    // back into the same register, the load is a no-op. When it reads into a
-    // different register, we can replace the load with a `MoveReg` (same
-    // 2-byte encoding) so the read still happens but the memory round-trip
-    // disappears.
-    //
-    // Guard: only eliminate when no label points at the load's byte offset,
-    // because branches from elsewhere may target the load and expect to see
-    // the value materialized in `dst`. Within a basic block produced by our
-    // emitter, adjacent Store+Load pairs are never branch targets, but we
-    // still verify in case `define_label` lands between the two emissions.
-    optimize_store_then_load(instructions, &mut keep, labels);
 
     compact_instructions(
         instructions,

--- a/crates/wasm-pvm/src/pvm/peephole.rs
+++ b/crates/wasm-pvm/src/pvm/peephole.rs
@@ -270,6 +270,22 @@ pub fn optimize(
     // 4. New: Fuse LoadImm + AddImm chains and chained AddImm operations.
     optimize_immediate_chains(instructions, &mut keep);
 
+    // 5. Eliminate StoreIndU64 → LoadIndU64 at the same (base, offset).
+    //
+    // After `store_to_slot(dst)` the value at `STACK_PTR + offset` is exactly
+    // what's in the source register. When a following `LoadIndU64` reads it
+    // back into the same register, the load is a no-op. When it reads into a
+    // different register, we can replace the load with a `MoveReg` (same
+    // 2-byte encoding) so the read still happens but the memory round-trip
+    // disappears.
+    //
+    // Guard: only eliminate when no label points at the load's byte offset,
+    // because branches from elsewhere may target the load and expect to see
+    // the value materialized in `dst`. Within a basic block produced by our
+    // emitter, adjacent Store+Load pairs are never branch targets, but we
+    // still verify in case `define_label` lands between the two emissions.
+    optimize_store_then_load(instructions, &mut keep, labels);
+
     compact_instructions(
         instructions,
         &keep,
@@ -378,6 +394,83 @@ fn optimize_immediate_chains(instructions: &mut [Instruction], keep: &mut [bool]
                     _ => unreachable!(),
                 }
             }
+        }
+    }
+}
+
+/// Eliminate redundant `LoadIndU64` immediately following a `StoreIndU64` at
+/// the same `(base, offset)`.
+///
+/// The store puts the value of `src` at `mem[base + offset]`. The load reads
+/// the same 8 bytes back into `dst`. If `dst == src`, the value is already in
+/// the register and the load is a pure no-op. If `dst != src`, the load
+/// becomes a register copy, which we encode as `MoveReg` (2 bytes — same as
+/// the smallest `LoadIndU64`).
+///
+/// Skipped if a label points at the load's byte offset (branches from
+/// elsewhere may target the load and depend on `dst` being materialized).
+fn optimize_store_then_load(
+    instructions: &mut [Instruction],
+    keep: &mut [bool],
+    labels: &[Option<usize>],
+) {
+    let len = instructions.len();
+    if len < 2 {
+        return;
+    }
+
+    // Byte offset of each instruction (so we can match against label targets).
+    let mut byte_offsets = Vec::with_capacity(len + 1);
+    let mut running = 0usize;
+    for instr in instructions.iter() {
+        byte_offsets.push(running);
+        running += instr.encode().len();
+    }
+    byte_offsets.push(running);
+
+    let labeled: BTreeSet<usize> = labels.iter().flatten().copied().collect();
+
+    for i in 0..len - 1 {
+        if !keep[i] || !keep[i + 1] {
+            continue;
+        }
+
+        let Instruction::StoreIndU64 {
+            base: s_base,
+            src: s_src,
+            offset: s_off,
+        } = instructions[i]
+        else {
+            continue;
+        };
+        let Instruction::LoadIndU64 {
+            dst: l_dst,
+            base: l_base,
+            offset: l_off,
+        } = instructions[i + 1]
+        else {
+            continue;
+        };
+        if s_base != l_base || s_off != l_off {
+            continue;
+        }
+        if labeled.contains(&byte_offsets[i + 1]) {
+            // Branch target — must not drop the load.
+            continue;
+        }
+
+        if l_dst == s_src {
+            // Pure no-op: value already in dst.
+            keep[i + 1] = false;
+        } else {
+            // Replace load with a register-to-register copy. Same byte length
+            // as the smallest LoadIndU64 encoding (2 bytes), so smaller-or-
+            // equal in all cases. The byte-offset recompute inside
+            // `compact_instructions` handles any size change.
+            instructions[i + 1] = Instruction::MoveReg {
+                dst: l_dst,
+                src: s_src,
+            };
         }
     }
 }

--- a/crates/wasm-pvm/tests/host_calls.rs
+++ b/crates/wasm-pvm/tests/host_calls.rs
@@ -153,19 +153,43 @@ fn test_host_call_2b_captures_r8() {
         instructions[ecalli_pos + 1]
     );
 
-    // `host_call_r8()` must retrieve the captured value somehow. With no
-    // intervening side-effectful work between the capture store and the
-    // retrieve load, the peephole at the end of compilation folds the
-    // round-trip into a register-to-register move from r8. Accept either
-    // shape: a LoadIndU64 (when the retrieve is no longer adjacent to the
-    // capture) or a MoveReg whose source is `r8` (a.k.a. `ARGS_LEN_REG`).
-    let has_load = has_opcode(&instructions, Opcode::LoadIndU64);
-    let has_move_from_r8 = instructions.iter().any(|i| {
-        matches!(i, wasm_pvm::pvm::Instruction::MoveReg { src, .. } if *src == wasm_pvm::abi::ARGS_LEN_REG)
+    // `host_call_r8()` must retrieve the captured value from the
+    // `R8_CAPTURE_SLOT_OFFSET` SP-relative slot. The lowering emits:
+    //   `LoadIndU64 { dst: TEMP_RESULT, base: STACK_PTR_REG,
+    //                 offset: R8_CAPTURE_SLOT_OFFSET }`
+    //
+    // With no intervening side-effectful work between the capture store
+    // and this retrieve load, the store-then-load peephole folds the
+    // adjacent round-trip into:
+    //   `MoveReg { dst: TEMP_RESULT, src: ARGS_LEN_REG }`
+    //
+    // (`ARGS_LEN_REG` == r8 == the StoreIndU64's source.) Accept exactly
+    // one of those two shapes so a regression that drops the retrieve
+    // entirely — or rewrites it to read the wrong slot or wrong register —
+    // is caught.
+    let retrieved_via_load = instructions.iter().any(|i| {
+        matches!(
+            i,
+            wasm_pvm::pvm::Instruction::LoadIndU64 { dst, base, offset }
+                if *dst == wasm_pvm::abi::TEMP_RESULT
+                    && *base == wasm_pvm::abi::STACK_PTR_REG
+                    && *offset == wasm_pvm::abi::R8_CAPTURE_SLOT_OFFSET
+        )
+    });
+    let retrieved_via_move = instructions.iter().any(|i| {
+        matches!(
+            i,
+            wasm_pvm::pvm::Instruction::MoveReg { dst, src }
+                if *dst == wasm_pvm::abi::TEMP_RESULT
+                    && *src == wasm_pvm::abi::ARGS_LEN_REG
+        )
     });
     assert!(
-        has_load || has_move_from_r8,
-        "Expected `host_call_r8` to retrieve r8 via LoadIndU64 or MoveReg from r8",
+        retrieved_via_load || retrieved_via_move,
+        "Expected `host_call_r8` to retrieve r8 either via \
+         `LoadIndU64 dst=TEMP_RESULT base=SP offset=R8_CAPTURE_SLOT_OFFSET` \
+         or via `MoveReg dst=TEMP_RESULT src=ARGS_LEN_REG` \
+         (peephole-folded). Instructions: {instructions:#?}",
     );
 }
 
@@ -425,9 +449,25 @@ fn test_host_call_r8_survives_helper_call() {
 
     // The r8 capture slot is SP-relative and preserved across calls because
     // the caller's SP doesn't change — callees get their own frame below.
-    // Verify the capture store and load are both present.
+    // With a real intervening function call between capture and retrieve,
+    // the store-then-load peephole can't fold the round-trip, so the
+    // retrieve MUST emit a `LoadIndU64` reading exactly the capture slot.
     assert!(has_opcode(&instructions, Opcode::Ecalli));
-    assert!(has_opcode(&instructions, Opcode::LoadIndU64));
+    let retrieve = instructions.iter().find(|i| {
+        matches!(
+            i,
+            wasm_pvm::pvm::Instruction::LoadIndU64 { dst, base, offset }
+                if *dst == wasm_pvm::abi::TEMP_RESULT
+                    && *base == wasm_pvm::abi::STACK_PTR_REG
+                    && *offset == wasm_pvm::abi::R8_CAPTURE_SLOT_OFFSET
+        )
+    });
+    assert!(
+        retrieve.is_some(),
+        "Expected `host_call_r8` to retrieve r8 via \
+         `LoadIndU64 dst=TEMP_RESULT base=SP offset=R8_CAPTURE_SLOT_OFFSET` \
+         after the intervening helper call. Instructions: {instructions:#?}",
+    );
 }
 
 #[test]

--- a/crates/wasm-pvm/tests/host_calls.rs
+++ b/crates/wasm-pvm/tests/host_calls.rs
@@ -153,8 +153,20 @@ fn test_host_call_2b_captures_r8() {
         instructions[ecalli_pos + 1]
     );
 
-    // Should also have a LoadIndU64 for host_call_r8.
-    assert!(has_opcode(&instructions, Opcode::LoadIndU64));
+    // `host_call_r8()` must retrieve the captured value somehow. With no
+    // intervening side-effectful work between the capture store and the
+    // retrieve load, the peephole at the end of compilation folds the
+    // round-trip into a register-to-register move from r8. Accept either
+    // shape: a LoadIndU64 (when the retrieve is no longer adjacent to the
+    // capture) or a MoveReg whose source is `r8` (a.k.a. `ARGS_LEN_REG`).
+    let has_load = has_opcode(&instructions, Opcode::LoadIndU64);
+    let has_move_from_r8 = instructions.iter().any(|i| {
+        matches!(i, wasm_pvm::pvm::Instruction::MoveReg { src, .. } if *src == wasm_pvm::abi::ARGS_LEN_REG)
+    });
+    assert!(
+        has_load || has_move_from_r8,
+        "Expected `host_call_r8` to retrieve r8 via LoadIndU64 or MoveReg from r8",
+    );
 }
 
 #[test]
@@ -376,11 +388,17 @@ fn test_host_call_5b_captures_r8() {
 fn test_host_call_r8_survives_helper_call() {
     // Verify the captured r8 slot (SP-relative) is not clobbered by an
     // intervening function call: host_call_2b → helper() → host_call_r8.
+    //
+    // The helper writes to a global so LLVM's DCE can't fold the call away
+    // and the intervening call really sits between capture and retrieve.
     let wat = r#"
         (module
             (import "env" "host_call_2b" (func $host_call_2b (param i64 i64 i64) (result i64)))
             (import "env" "host_call_r8" (func $host_call_r8 (result i64)))
-            (func $helper (result i32) (i32.const 99))
+            (global $g (mut i32) (i32.const 0))
+            (func $helper (result i32)
+                (global.set $g (i32.const 1))
+                (i32.const 99))
             (func (export "main") (param i32 i32) (result i32)
                 (drop (call $host_call_2b (i64.const 10) (i64.const 100) (i64.const 200)))
                 (drop (call $helper))

--- a/examples/polkadot/.gitignore
+++ b/examples/polkadot/.gitignore
@@ -4,3 +4,4 @@ jam/
 logs/
 imports/
 floats/
+__pycache__/

--- a/examples/polkadot/analyze-jam.py
+++ b/examples/polkadot/analyze-jam.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Analyze a JAM/SPI program blob: count opcode frequency and instruction sizes.
+
+Pairs with the SPI parser in tests/utils/verify-jam.ts but produces a histogram
+ranked by both frequency and total bytes contributed.
+"""
+import struct
+import sys
+from collections import Counter
+
+OPCODES = {
+    0: "Trap", 1: "Fallthrough", 10: "Ecalli", 20: "LoadImm64",
+    30: "StoreImmU8", 31: "StoreImmU16", 32: "StoreImmU32", 33: "StoreImmU64",
+    40: "Jump", 50: "JumpInd", 51: "LoadImm",
+    52: "LoadU8", 53: "LoadI8", 54: "LoadU16", 55: "LoadI16",
+    56: "LoadU32", 57: "LoadI32", 58: "LoadU64",
+    59: "StoreU8", 60: "StoreU16", 61: "StoreU32", 62: "StoreU64",
+    70: "StoreImmIndU8", 71: "StoreImmIndU16", 72: "StoreImmIndU32", 73: "StoreImmIndU64",
+    80: "LoadImmJump",
+    81: "BranchEqImm", 82: "BranchNeImm",
+    83: "BranchLtUImm", 84: "BranchLeUImm", 85: "BranchGeUImm", 86: "BranchGtUImm",
+    87: "BranchLtSImm", 88: "BranchLeSImm", 89: "BranchGeSImm", 90: "BranchGtSImm",
+    100: "MoveReg", 101: "Sbrk",
+    102: "CountSetBits64", 103: "CountSetBits32",
+    104: "LeadingZeroBits64", 105: "LeadingZeroBits32",
+    106: "TrailingZeroBits64", 107: "TrailingZeroBits32",
+    108: "SignExtend8", 109: "SignExtend16", 110: "ZeroExtend16", 111: "ReverseBytes",
+    120: "StoreIndU8", 121: "StoreIndU16", 122: "StoreIndU32", 123: "StoreIndU64",
+    124: "LoadIndU8", 125: "LoadIndI8", 126: "LoadIndU16", 127: "LoadIndI16",
+    128: "LoadIndU32", 129: "LoadIndI32", 130: "LoadIndU64",
+    131: "AddImm32", 132: "AndImm", 133: "XorImm", 134: "OrImm",
+    135: "MulImm32", 136: "SetLtUImm", 137: "SetLtSImm",
+    138: "ShloLImm32", 139: "ShloRImm32", 140: "SharRImm32",
+    141: "NegAddImm32", 142: "SetGtUImm", 143: "SetGtSImm",
+    144: "ShloLImmAlt32", 145: "ShloRImmAlt32", 146: "SharRImmAlt32",
+    147: "CmovIzImm", 148: "CmovNzImm",
+    149: "AddImm64", 150: "MulImm64",
+    151: "ShloLImm64", 152: "ShloRImm64", 153: "SharRImm64",
+    154: "NegAddImm64",
+    155: "ShloLImmAlt64", 156: "ShloRImmAlt64", 157: "SharRImmAlt64",
+    158: "RotRImm64", 159: "RotRImmAlt64", 160: "RotRImm32", 161: "RotRImmAlt32",
+    170: "BranchEq", 171: "BranchNe",
+    172: "BranchLtU", 173: "BranchLtS", 174: "BranchGeU", 175: "BranchGeS",
+    180: "LoadImmJumpInd",
+    190: "Add32", 191: "Sub32", 192: "Mul32",
+    193: "DivU32", 194: "DivS32", 195: "RemU32", 196: "RemS32",
+    197: "ShloL32", 198: "ShloR32", 199: "SharR32",
+    200: "Add64", 201: "Sub64", 202: "Mul64",
+    203: "DivU64", 204: "DivS64", 205: "RemU64", 206: "RemS64",
+    207: "ShloL64", 208: "ShloR64", 209: "SharR64",
+    210: "And", 211: "Xor", 212: "Or",
+    213: "MulUpperSS", 214: "MulUpperUU", 215: "MulUpperSU",
+    216: "SetLtU", 217: "SetLtS",
+    218: "CmovIz", 219: "CmovNz",
+    220: "RotL64", 221: "RotL32", 222: "RotR64", 223: "RotR32",
+    224: "AndInv", 225: "OrInv", 226: "Xnor",
+    227: "Max", 228: "MaxU", 229: "Min", 230: "MinU",
+}
+
+
+def read_var_u32(data, off):
+    fb = data[off]
+    if fb < 0x80:
+        return fb, 1
+    if fb < 0xc0:
+        return ((fb - 0x80) << 8) | data[off + 1], 2
+    if fb < 0xe0:
+        return ((fb - 0xc0) << 16) | data[off + 1] | (data[off + 2] << 8), 3
+    if fb < 0xf0:
+        return ((fb - 0xe0) << 24) | data[off + 1] | (data[off + 2] << 8) | (data[off + 3] << 16), 4
+    return struct.unpack_from("<Q", data, off + 1)[0], 9
+
+
+def parse_jam(path):
+    with open(path, "rb") as f:
+        data = f.read()
+
+    off = 0
+    # Metadata prefix: varint length + metadata bytes
+    meta_len, n = read_var_u32(data, off); off += n
+    off += meta_len
+    ro_len = int.from_bytes(data[off:off+3], "little"); off += 3
+    rw_len = int.from_bytes(data[off:off+3], "little"); off += 3
+    heap_pages = int.from_bytes(data[off:off+2], "little"); off += 2
+    stack_size = int.from_bytes(data[off:off+3], "little"); off += 3
+    off += ro_len + rw_len  # skip ro/rw data
+    code_total_len = int.from_bytes(data[off:off+4], "little"); off += 4
+
+    blob_start = off
+    jt_len, n = read_var_u32(data, off); off += n
+    jt_item_bytes = data[off]; off += 1
+    blob_code_len, n = read_var_u32(data, off); off += n
+
+    off += jt_len * jt_item_bytes  # skip jump table
+    code_start = off
+    code = data[code_start:code_start + blob_code_len]
+    mask = data[code_start + blob_code_len:]
+    return code, mask, {
+        "ro_len": ro_len,
+        "rw_len": rw_len,
+        "heap_pages": heap_pages,
+        "stack_size": stack_size,
+        "jt_entries": jt_len,
+        "code_len": blob_code_len,
+    }
+
+
+def iter_instructions(code, mask):
+    """Yield (start_offset, length, opcode) tuples."""
+    n = len(code)
+    # Convert mask to a list of instruction-start positions.
+    starts = []
+    for byte_idx, byte in enumerate(mask):
+        for bit_idx in range(8):
+            pos = byte_idx * 8 + bit_idx
+            if pos >= n:
+                break
+            if (byte >> bit_idx) & 1:
+                starts.append(pos)
+    starts.append(n)
+    for i in range(len(starts) - 1):
+        start, end = starts[i], starts[i + 1]
+        yield start, end - start, code[start]
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: analyze-jam.py <jam-file>", file=sys.stderr)
+        sys.exit(1)
+    path = sys.argv[1]
+    code, mask, meta = parse_jam(path)
+
+    freq = Counter()
+    size = Counter()
+    pair_freq = Counter()  # consecutive opcode pairs
+    prev_op = None
+    total_instrs = 0
+    for _start, length, op in iter_instructions(code, mask):
+        name = OPCODES.get(op, f"Opcode_{op}")
+        freq[name] += 1
+        size[name] += length
+        if prev_op is not None:
+            pair_freq[(prev_op, name)] += 1
+        prev_op = name
+        total_instrs += 1
+
+    total_bytes = sum(size.values())
+    print(f"File: {path}")
+    print(f"Code: {meta['code_len']:,} bytes  Jump-table: {meta['jt_entries']:,} entries")
+    print(f"Total instructions: {total_instrs:,}")
+    print(f"Avg encoded size: {total_bytes / max(1, total_instrs):.2f} bytes/instr")
+    print()
+
+    print(f"{'Opcode':<24} {'Count':>10} {'%':>6} {'Bytes':>12} {'%':>6} {'AvgSz':>6}")
+    print("-" * 72)
+    for name, cnt in freq.most_common(40):
+        bcnt = size[name]
+        avg = bcnt / cnt if cnt else 0
+        pct_c = 100.0 * cnt / total_instrs
+        pct_b = 100.0 * bcnt / total_bytes
+        print(f"{name:<24} {cnt:>10,} {pct_c:>6.2f} {bcnt:>12,} {pct_b:>6.2f} {avg:>6.2f}")
+
+    print()
+    print("=== Top consecutive instruction pairs (size opportunities) ===")
+    for (a, b), cnt in pair_freq.most_common(25):
+        pct = 100.0 * cnt / max(1, total_instrs - 1)
+        print(f"  {a:<22} → {b:<22} {cnt:>10,}  ({pct:>5.2f}%)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/polkadot/analyze-jam.py
+++ b/examples/polkadot/analyze-jam.py
@@ -77,24 +77,47 @@ def parse_jam(path):
 
     off = 0
     # Metadata prefix: varint length + metadata bytes
-    meta_len, n = read_var_u32(data, off); off += n
+    meta_len, n = read_var_u32(data, off)
+    off += n
     off += meta_len
-    ro_len = int.from_bytes(data[off:off+3], "little"); off += 3
-    rw_len = int.from_bytes(data[off:off+3], "little"); off += 3
-    heap_pages = int.from_bytes(data[off:off+2], "little"); off += 2
-    stack_size = int.from_bytes(data[off:off+3], "little"); off += 3
+    ro_len = int.from_bytes(data[off:off+3], "little")
+    off += 3
+    rw_len = int.from_bytes(data[off:off+3], "little")
+    off += 3
+    heap_pages = int.from_bytes(data[off:off+2], "little")
+    off += 2
+    stack_size = int.from_bytes(data[off:off+3], "little")
+    off += 3
     off += ro_len + rw_len  # skip ro/rw data
-    code_total_len = int.from_bytes(data[off:off+4], "little"); off += 4
+    code_total_len = int.from_bytes(data[off:off+4], "little")
+    off += 4
+    blob_end = off + code_total_len
+    if blob_end > len(data):
+        raise ValueError(
+            f"Invalid JAM: declared code blob ({code_total_len} bytes) "
+            f"exceeds remaining file size ({len(data) - off} bytes)"
+        )
 
     blob_start = off
-    jt_len, n = read_var_u32(data, off); off += n
-    jt_item_bytes = data[off]; off += 1
-    blob_code_len, n = read_var_u32(data, off); off += n
+    jt_len, n = read_var_u32(data, off)
+    off += n
+    jt_item_bytes = data[off]
+    off += 1
+    blob_code_len, n = read_var_u32(data, off)
+    off += n
 
     off += jt_len * jt_item_bytes  # skip jump table
     code_start = off
-    code = data[code_start:code_start + blob_code_len]
-    mask = data[code_start + blob_code_len:]
+    code_end = code_start + blob_code_len
+    if code_end > blob_end:
+        raise ValueError(
+            f"Invalid JAM: code section ({blob_code_len} bytes from "
+            f"offset {code_start}) extends past the declared blob end"
+        )
+    code = data[code_start:code_end]
+    # Mask is bounded by the declared code blob length so trailing bytes
+    # (if any) don't get folded into instruction-start counting.
+    mask = data[code_end:blob_end]
     return code, mask, {
         "ro_len": ro_len,
         "rw_len": rw_len,

--- a/examples/polkadot/measure.sh
+++ b/examples/polkadot/measure.sh
@@ -25,5 +25,9 @@ JAM="$THIS_DIR/jam/glutton-kusama.jam"
   }
 
 # Pull the headline numbers out of the analyzer's first ~5 lines.
-python3 "$THIS_DIR/analyze-jam.py" "$JAM" | head -5
+# Capture the output first so `head` exiting early doesn't SIGPIPE the
+# producer (which would trip `set -o pipefail` and abort the script
+# before the final JAM-size echo runs).
+ANALYZE_OUT="$(python3 "$THIS_DIR/analyze-jam.py" "$JAM")"
+printf '%s\n' "$ANALYZE_OUT" | head -5
 echo "JAM bytes: $(stat -f%z "$JAM" 2>/dev/null || stat -c%s "$JAM")"

--- a/examples/polkadot/measure.sh
+++ b/examples/polkadot/measure.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Recompile glutton-kusama with the freshly built CLI and report code-size +
+# instruction-count metrics. Intended for per-commit verification while
+# iterating on optimizations.
+set -euo pipefail
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$THIS_DIR/../.." && pwd)"
+WASM_PVM="$PROJECT_ROOT/target/release/wasm-pvm"
+
+WASM="$THIS_DIR/wasm/glutton-kusama.wasm"
+IMPORTS="$THIS_DIR/imports/glutton-kusama.imports"
+JAM="$THIS_DIR/jam/glutton-kusama.jam"
+
+[ -x "$WASM_PVM" ] || { echo "ERROR: build the release binary first"; exit 1; }
+[ -f "$WASM" ]      || { echo "ERROR: missing $WASM";                exit 1; }
+[ -f "$IMPORTS" ]   || { echo "ERROR: missing $IMPORTS";             exit 1; }
+
+# Recompile (logs to stderr; quiet stdout).
+"$WASM_PVM" compile "$WASM" -o "$JAM" --imports "$IMPORTS" --trap-floats \
+  >/tmp/glutton-compile.log 2>&1 || {
+    echo "COMPILE FAILED:"
+    tail -30 /tmp/glutton-compile.log
+    exit 1
+  }
+
+# Pull the headline numbers out of the analyzer's first ~5 lines.
+python3 "$THIS_DIR/analyze-jam.py" "$JAM" | head -5
+echo "JAM bytes: $(stat -f%z "$JAM" 2>/dev/null || stat -c%s "$JAM")"


### PR DESCRIPTION
## Summary

Four backend micro-optimizations that close part of the WASM↔PVM gap on substrate/polkadot-fellows runtimes:

- **i32→i64 zext via immediate-form shifts** (replaces `LoadImm + ShloL64 + ShloR64` with `ShloLImm64 + ShloRImm64`) — biggest win, frees TEMP2.
- **`*ImmAlt` shifts when shift LHS is a small constant** (e.g. `1 << x` bitmask idiom) — exercises previously-unused opcodes 144-146/155-157.
- **`RotRImm32/64` for constant-amount rotations** in `llvm.fshl`/`fshr` lowering — substrate hashing primitives benefit; `rotl(x, n)` rewritten as `rotr(x, w - n)` since PVM has no `RotLImm`.
- **Peephole `StoreIndU64 + LoadIndU64` elimination** at same `(base, offset)` — drops the load (or rewrites to `MoveReg`). Label-aware so a branch target is never folded.

Plus one chore commit (`analyze-jam.py` + `measure.sh`) that the rest of the series depended on to measure per-commit impact.

## Benchmark (vs. `main`)

Polkadot fellowship runtimes (`--trap-floats`):

| Runtime | WASM | JAM (main) | JAM (this) | JAM Δ | Code (main) | Code (this) | Code Δ | Insns (main) | Insns (this) | Insns Δ |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| glutton-kusama | 2.04 MiB | 7,195,736 | 7,034,075 | **-2.25%** | 5,304,464 | 5,160,765 | **-2.71%** | 1,470,183 | 1,422,678 | **-3.23%** |
| bridge-hub-kusama | 4.82 MiB | 15,259,645 | 14,901,836 | **-2.34%** | 12,111,882 | 11,793,830 | **-2.63%** | 3,320,755 | 3,215,587 | **-3.17%** |

Hand-written fixtures + AS modules:

| Fixture | JAM (main) | JAM (this) | JAM Δ | Code (main) | Code (this) | Code Δ |
|---|---:|---:|---:|---:|---:|---:|
| add(5,7) | 164 | 164 | 0.00% | 99 | 99 | 0.00% |
| fib(20) | 226 | 223 | -1.33% | 148 | 145 | -2.03% |
| factorial(10) | 198 | 195 | -1.52% | 124 | 121 | -2.42% |
| is_prime(25) | 285 | 285 | 0.00% | 201 | 201 | 0.00% |
| AS fib(10) | 631 | 618 | -2.06% | 504 | 492 | -2.38% |
| AS factorial(7) | 616 | 602 | -2.27% | 490 | 478 | -2.45% |
| AS decoder | 6,806 | 6,675 | -1.92% | 4,944 | 4,827 | -2.37% |
| AS array | 6,211 | 6,086 | -2.01% | 4,427 | 4,316 | -2.51% |
| blake2b(`abc`, 32) | 4,063 | 4,033 | -0.74% | 2,751 | 2,724 | -0.98% |
| sha512(`abc`) | 3,791 | 3,727 | -1.69% | 2,559 | 2,502 | -2.23% |

The pattern is consistent: **~2-3% code-size reduction across the board, ~3% fewer PVM instructions executed**. Bigger relative wins on programs that do a lot of narrow-int handling (AS, scale codec); smaller wins on tight numeric kernels (blake2b).

## Test plan

- [x] 438 cargo unit + integration tests pass (incl. host_calls suite with two test assertions relaxed to allow MoveReg-from-r8 in place of LoadIndU64 — see commit `b7c2edf` body for rationale)
- [x] 653 Layer 1-3 TypeScript integration tests pass
- [x] 6 Layer 4 PVM-in-PVM smoke tests pass
- [x] Pre-push hook (cargo test + clippy + bun integration) ran green before push
- [ ] Layer 5 comprehensive PVM-in-PVM suite (run in CI after merge?)
- [ ] Differential suite (`bun run test:differential`) — recommend running locally before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)