### PR TITLE
perf(regalloc): allocate r9-r12 past max_call_args in non-leaf functions

### DIFF
--- a/crates/wasm-pvm/src/llvm_backend/regalloc.rs
+++ b/crates/wasm-pvm/src/llvm_backend/regalloc.rs
@@ -232,13 +232,18 @@ pub fn run(
     }
 
     // Add callee-saved registers (r9-r12) beyond parameter count.
-    // For non-leaf functions, reserve outgoing argument registers (r9..)
-    // based on the function's max call arity, since call setup writes them.
-    let first_alloc_idx = if is_leaf {
-        num_params
-    } else {
-        num_params.max(max_call_args.min(crate::abi::MAX_LOCAL_REGS))
-    };
+    // Outgoing call argument registers (r9..r9+arity-1) are still allocatable
+    // in non-leaf functions: the call lowering spills dirty allocated values
+    // via `spill_allocated_regs()` before each call and clears alloc state via
+    // `clear_reg_cache()` after, so subsequent uses lazy-reload from the
+    // canonical stack slot. This is the same mechanism that lets r5/r6 be
+    // allocatable in non-leaf functions.
+    //
+    // We still reserve parameter registers (r9..r9+num_params-1): they hold
+    // incoming values at function entry, and making them allocatable to
+    // non-param values causes correctness failures in tests with parameter
+    // overflow / loop back-edges (see integration tests).
+    let first_alloc_idx = num_params;
     for i in first_alloc_idx..crate::abi::MAX_LOCAL_REGS {
         allocatable_regs.push(crate::abi::FIRST_LOCAL_REG + i as u8);
     }


### PR DESCRIPTION
## Summary

- Non-leaf functions reserved `r9..r9+max_call_args` entirely, making them
  unallocatable for the whole function. Combined with `scratch_regs_safe=false`
  (bulk memory ops, funnel shifts, i64 sat arith), this could leave
  `allocatable_regs` empty and trip the `insufficient_nonleaf_regs` skip —
  disabling regalloc for whole functions.
- The call lowering already spills dirty allocated values via
  `spill_allocated_regs()` before each call and clears the cache via
  `clear_reg_cache()` after, so allocated `r9-r12` entries lazy-reload on next
  use — the same mechanism that already lets `r5/r6` be allocatable in
  non-leaf functions. The `max_call_args` reservation was unnecessarily
  conservative.
- Dropping the `.max(max_call_args.min(MAX_LOCAL_REGS))` clamp leaves
  `first_alloc_idx = num_params` uniformly across leaf/non-leaf.

## Benchmark results

### Polkadot fellowship runtimes (compile-time stats — full runtimes too large to execute)

| Runtime | Skipped fns | Allocated values | JAM size | Emitted instructions |
|---|---|---|---|---|
| bridge-hub-kusama (5 MiB WASM → 15 MiB JAM) | 39 → 19 (**-51%**) | +45.6% | -54 KB (-0.4%) | -14 199 (-0.4%) |
| glutton-kusama (2 MiB WASM → 7 MiB JAM) | 19 → 9 (**-53%**) | +42.4% | -19 KB (-0.3%) | -4 908 (-0.3%) |

### Small fixtures — direct execution

| Benchmark | Skip Δ | Alloc Δ | JAM Δ | Gas Δ |
|---|---|---|---|---|
| blake2b(abc,32) | **1 → 0** | 10 → 24 | -1.6% | **-0.4%** |
| aslan-ecalli | **2 → 0** | 522 → 601 | -0.05% | **-1.5%** |
| aslan-fib(42) | 0/0 | 184 → 213 | -0.4% | +0.3% |
| add / fib(20) / factorial(10) / sha512(abc) | 0/0 | unchanged | 0% | 0% |

`aslan-fib` shows a small regression (+0.3% gas, +38 absolute) from extra
spill traffic at recursive call sites — the only workload here where allocating
to caller-saved regs is net-negative.

### PVM-in-PVM (outer gas)

| Benchmark | Baseline | Experimental | Δ |
|---|---|---|---|
| blake2b | 16 314 216 | 16 197 236 | **-0.72%** |
| Others (no skipped fns) | unchanged | unchanged | 0.00% |

## Test plan

- [x] `cargo test --release` — 438 pass / 0 fail
- [x] `cd tests && bun run test` — 653 pass / 0 fail (layers 1–3)
- [x] `bun test layer4/ layer5/ --test-name-pattern "pvm-in-pvm"` — 277 pass / 0 fail
- [x] `bun run test:differential` — 142 pass / 0 fail
- [x] `cargo clippy --release -p wasm-pvm --lib -- -D warnings` — clean
- [x] Manual regalloc inspection — `wasm_func_107` / `wasm_func_104` in
  aslan-ecalli now report `allocatable_regs=2` (r11, r12) and 4-5 allocated
  values instead of skipping.

## What didn't work (left as future work)

Tried `first_alloc_idx = 0` to also allocate parameter registers (r9..r9+num_params-1)
once params die. Compiles, but fails 81 integration tests
(`regalloc-two-loops`, `regalloc-backedge-callee-saved`, `aslan-fib`). The
interaction between param live-intervals (starting at instr 0), the prologue's
`store_to_slot(param_slot, r9)`, and loop back-edge propagation produces
incorrect codegen in ways I didn't fully trace. The conservative
`first_alloc_idx = num_params` change is what landed.

The remaining `insufficient_nonleaf_regs` skips now require **both**
`num_params >= 4` **and** `scratch_regs_safe = false` — the narrow tail of
4-arg functions that also use bulk memory / funnel shifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)