### PR TITLE
feat(backend): extend operand_reg cache lookup with sibling-aware avoid list

### DIFF
--- a/crates/wasm-pvm/src/llvm_backend/alu.rs
+++ b/crates/wasm-pvm/src/llvm_backend/alu.rs
@@ -20,8 +20,9 @@ use crate::Result;
 use crate::pvm::Instruction;
 
 use super::emitter::{
-    FusedIcmp, PvmEmitter, SCRATCH1, get_operand, operand_bit_width, operand_reg, result_reg,
-    result_reg_or, result_slot, source_bit_width, try_get_constant,
+    FusedIcmp, PvmEmitter, SCRATCH1, get_operand, operand_bit_width, operand_reg,
+    operand_reg_avoiding, result_reg, result_reg_or, result_slot, source_bit_width,
+    try_get_constant,
 };
 use crate::abi::{TEMP_RESULT, TEMP1, TEMP2};
 
@@ -432,8 +433,8 @@ pub fn lower_binary_arith<'ctx>(
             .or_else(|| try_get_bitwise_not(lhs).map(|inner| (rhs, inner)));
 
         if let Some((plain, inv_inner)) = fused_pair {
-            let mut plain_reg = operand_reg(e, plain, TEMP1);
-            let mut inv_reg = operand_reg(e, inv_inner, TEMP2);
+            let mut plain_reg = operand_reg_avoiding(e, plain, TEMP1, &[TEMP2]);
+            let mut inv_reg = operand_reg_avoiding(e, inv_inner, TEMP2, &[TEMP1]);
             if plain_reg != TEMP1 && plain_reg == dst {
                 plain_reg = TEMP1;
             }
@@ -484,8 +485,8 @@ pub fn lower_binary_arith<'ctx>(
         e.load_operand(rhs, TEMP2)?;
         (TEMP1, TEMP2)
     } else {
-        let mut lhs_reg = operand_reg(e, lhs, TEMP1);
-        let mut rhs_reg = operand_reg(e, rhs, TEMP2);
+        let mut lhs_reg = operand_reg_avoiding(e, lhs, TEMP1, &[TEMP2]);
+        let mut rhs_reg = operand_reg_avoiding(e, rhs, TEMP2, &[TEMP1]);
         if lhs_reg != TEMP1 && lhs_reg == dst {
             lhs_reg = TEMP1;
         }
@@ -776,8 +777,8 @@ pub fn lower_icmp<'ctx>(e: &mut PvmEmitter<'ctx>, instr: InstructionValue<'ctx>)
     }
 
     // Load-side coalescing for register-register comparisons.
-    let mut lhs_reg = operand_reg(e, lhs, TEMP1);
-    let mut rhs_reg = operand_reg(e, rhs, TEMP2);
+    let mut lhs_reg = operand_reg_avoiding(e, lhs, TEMP1, &[TEMP2]);
+    let mut rhs_reg = operand_reg_avoiding(e, rhs, TEMP2, &[TEMP1]);
     if lhs_reg != TEMP1 && lhs_reg == dst {
         lhs_reg = TEMP1;
     }
@@ -1077,9 +1078,9 @@ pub fn lower_select<'ctx>(e: &mut PvmEmitter<'ctx>, instr: InstructionValue<'ctx
 
     if let Some(tv) = true_const {
         // true_val is constant: load false_val as default, CmovNzImm overwrites if cond != 0
-        let def_reg = operand_reg(e, false_val, TEMP_RESULT);
+        let def_reg = operand_reg_avoiding(e, false_val, TEMP_RESULT, &[TEMP1]);
         e.load_operand(false_val, def_reg)?;
-        let cond_reg = operand_reg(e, cond, TEMP1);
+        let cond_reg = operand_reg_avoiding(e, cond, TEMP1, &[TEMP_RESULT]);
         e.load_operand(cond, cond_reg)?;
         e.emit(Instruction::CmovNzImm {
             dst: def_reg,
@@ -1089,9 +1090,9 @@ pub fn lower_select<'ctx>(e: &mut PvmEmitter<'ctx>, instr: InstructionValue<'ctx
         e.store_to_slot(slot, def_reg);
     } else if let Some(fv) = false_const {
         // false_val is constant: load true_val as default, CmovIzImm overwrites if cond == 0
-        let def_reg = operand_reg(e, true_val, TEMP_RESULT);
+        let def_reg = operand_reg_avoiding(e, true_val, TEMP_RESULT, &[TEMP1]);
         e.load_operand(true_val, def_reg)?;
-        let cond_reg = operand_reg(e, cond, TEMP1);
+        let cond_reg = operand_reg_avoiding(e, cond, TEMP1, &[TEMP_RESULT]);
         e.load_operand(cond, cond_reg)?;
         e.emit(Instruction::CmovIzImm {
             dst: def_reg,
@@ -1102,11 +1103,11 @@ pub fn lower_select<'ctx>(e: &mut PvmEmitter<'ctx>, instr: InstructionValue<'ctx
     } else if let Some(inner_cond) = try_get_inverted_condition(cond) {
         // Inverted condition: select(!c, tv, fv) ≡ select(c, fv, tv)
         // Use CmovIz: load false_val as default, overwrite with true_val when inner_cond==0
-        let def_reg = operand_reg(e, false_val, TEMP_RESULT);
+        let def_reg = operand_reg_avoiding(e, false_val, TEMP_RESULT, &[TEMP1, TEMP2]);
         e.load_operand(false_val, def_reg)?;
-        let src_reg = operand_reg(e, true_val, TEMP2);
+        let src_reg = operand_reg_avoiding(e, true_val, TEMP2, &[TEMP_RESULT, TEMP1]);
         e.load_operand(true_val, src_reg)?;
-        let cond_reg = operand_reg(e, inner_cond, TEMP1);
+        let cond_reg = operand_reg_avoiding(e, inner_cond, TEMP1, &[TEMP_RESULT, TEMP2]);
         e.load_operand(inner_cond, cond_reg)?;
         e.emit(Instruction::CmovIz {
             dst: def_reg,
@@ -1116,11 +1117,11 @@ pub fn lower_select<'ctx>(e: &mut PvmEmitter<'ctx>, instr: InstructionValue<'ctx
         e.store_to_slot(slot, def_reg);
     } else {
         // Neither is a small constant: use register CmovNz
-        let def_reg = operand_reg(e, false_val, TEMP_RESULT);
+        let def_reg = operand_reg_avoiding(e, false_val, TEMP_RESULT, &[TEMP1, TEMP2]);
         e.load_operand(false_val, def_reg)?;
-        let src_reg = operand_reg(e, true_val, TEMP2);
+        let src_reg = operand_reg_avoiding(e, true_val, TEMP2, &[TEMP_RESULT, TEMP1]);
         e.load_operand(true_val, src_reg)?;
-        let cond_reg = operand_reg(e, cond, TEMP1);
+        let cond_reg = operand_reg_avoiding(e, cond, TEMP1, &[TEMP_RESULT, TEMP2]);
         e.load_operand(cond, cond_reg)?;
         e.emit(Instruction::CmovNz {
             dst: def_reg,

--- a/crates/wasm-pvm/src/llvm_backend/control_flow.rs
+++ b/crates/wasm-pvm/src/llvm_backend/control_flow.rs
@@ -22,7 +22,7 @@ use crate::{Error, Result, abi};
 
 use super::emitter::{
     PvmEmitter, SCRATCH1, SCRATCH2, get_bb_operand, get_operand, has_phi_from, operand_reg,
-    result_slot, try_get_constant, val_key_basic, val_key_instr,
+    operand_reg_avoiding, result_slot, try_get_constant, val_key_basic, val_key_instr,
 };
 use crate::abi::{STACK_PTR_REG, TEMP_RESULT, TEMP1, TEMP2};
 
@@ -352,8 +352,8 @@ fn emit_fused_branch<'a>(
         return Ok(());
     }
 
-    let lhs_reg = operand_reg(e, fused.lhs, TEMP1);
-    let rhs_reg = operand_reg(e, fused.rhs, TEMP2);
+    let lhs_reg = operand_reg_avoiding(e, fused.lhs, TEMP1, &[TEMP2]);
+    let rhs_reg = operand_reg_avoiding(e, fused.rhs, TEMP2, &[TEMP1]);
     if lhs_reg == TEMP1 {
         e.load_operand(fused.lhs, TEMP1)?;
     }

--- a/crates/wasm-pvm/src/llvm_backend/emitter.rs
+++ b/crates/wasm-pvm/src/llvm_backend/emitter.rs
@@ -1181,6 +1181,31 @@ pub fn result_reg_or(e: &PvmEmitter<'_>, instr: InstructionValue<'_>, fallback: 
 /// Used for load-side coalescing: callers can use the allocated register directly as an
 /// instruction operand instead of copying to a temp register via `load_operand`.
 pub fn operand_reg(e: &PvmEmitter<'_>, val: BasicValueEnum<'_>, fallback: u8) -> u8 {
+    operand_reg_avoiding(e, val, fallback, &[])
+}
+
+/// Variant of [`operand_reg`] that avoids returning specific registers.
+///
+/// Multi-operand callers (binary arithmetic, stores, cmov, ...) issue several
+/// `load_operand` calls into distinct scratch registers (e.g. lhs → `TEMP1`,
+/// rhs → `TEMP2`). The per-block `slot_cache` may report that some other value
+/// is currently sitting in one of those scratch registers — but if we return
+/// that scratch register here, the sibling `load_operand` call will overwrite
+/// it before the emitted instruction reads it, producing a `Add r4, r2, r2`
+/// kind of aliasing where both operands collapse to the same scratch value.
+///
+/// `avoid` lists the scratch registers reserved as load targets for *other*
+/// operands at the same call site. The cache lookup skips any cached register
+/// that appears in `avoid`, falling back to the operand's own fallback so a
+/// fresh load can populate a non-conflicting register.
+///
+/// Single-operand callers (no sibling load) can use [`operand_reg`] directly.
+pub fn operand_reg_avoiding(
+    e: &PvmEmitter<'_>,
+    val: BasicValueEnum<'_>,
+    fallback: u8,
+    avoid: &[u8],
+) -> u8 {
     if let BasicValueEnum::IntValue(iv) = val {
         // Constants don't have allocated registers.
         if iv.get_sign_extended_constant().is_some() || iv.get_zero_extended_constant().is_some() {
@@ -1190,11 +1215,23 @@ pub fn operand_reg(e: &PvmEmitter<'_>, val: BasicValueEnum<'_>, fallback: u8) ->
             return fallback;
         }
         let key = val_key_int(iv);
-        if let Some(&alloc_reg) = e.regalloc.val_to_reg.get(&key)
-            && let Some(slot) = e.get_slot(key)
-            && e.alloc_reg_slot[alloc_reg as usize] == Some(slot)
-        {
-            return alloc_reg;
+        if let Some(slot) = e.get_slot(key) {
+            // Narrow path: value's allocated register currently holds the slot.
+            if let Some(&alloc_reg) = e.regalloc.val_to_reg.get(&key)
+                && e.alloc_reg_slot[alloc_reg as usize] == Some(slot)
+            {
+                return alloc_reg;
+            }
+            // Broader path: per-block cache says the value is in some register
+            // (e.g. it was previously loaded into `TEMP1` for another use). Use
+            // it directly to skip the load — but only if a sibling load won't
+            // clobber it before our emit reads it.
+            if let Some(&cached_reg) = e.slot_cache.get(&slot)
+                && cached_reg != fallback
+                && !avoid.contains(&cached_reg)
+            {
+                return cached_reg;
+            }
         }
     }
     fallback

--- a/crates/wasm-pvm/src/llvm_backend/intrinsics.rs
+++ b/crates/wasm-pvm/src/llvm_backend/intrinsics.rs
@@ -17,8 +17,8 @@ use crate::Result;
 use crate::pvm::Instruction;
 
 use super::emitter::{
-    LoweringContext, PvmEmitter, get_operand, operand_bit_width, operand_reg, result_reg,
-    result_slot, try_get_constant, val_key_basic,
+    LoweringContext, PvmEmitter, get_operand, operand_bit_width, operand_reg, operand_reg_avoiding,
+    result_reg, result_slot, try_get_constant, val_key_basic,
 };
 use super::memory::{
     PvmLoadKind, PvmStoreKind, emit_pvm_data_drop, emit_pvm_load, emit_pvm_memory_copy,
@@ -135,8 +135,8 @@ pub fn lower_llvm_intrinsic<'ctx>(
         // source of the sign extension, but the min/max itself uses TEMP1/TEMP2
         // (which hold the sign-extended values).
         let (a_reg, b_reg) = if is_signed && bits == 32 {
-            let a_src = operand_reg(e, a, TEMP1);
-            let b_src = operand_reg(e, b, TEMP2);
+            let a_src = operand_reg_avoiding(e, a, TEMP1, &[TEMP2]);
+            let b_src = operand_reg_avoiding(e, b, TEMP2, &[TEMP1]);
             if a_src == TEMP1 {
                 e.load_operand(a, TEMP1)?;
             }
@@ -155,8 +155,8 @@ pub fn lower_llvm_intrinsic<'ctx>(
             });
             (TEMP1, TEMP2)
         } else {
-            let mut a_reg = operand_reg(e, a, TEMP1);
-            let mut b_reg = operand_reg(e, b, TEMP2);
+            let mut a_reg = operand_reg_avoiding(e, a, TEMP1, &[TEMP2]);
+            let mut b_reg = operand_reg_avoiding(e, b, TEMP2, &[TEMP1]);
             if a_reg != TEMP1 && a_reg == dst {
                 a_reg = TEMP1;
             }
@@ -506,7 +506,10 @@ pub fn lower_llvm_intrinsic<'ctx>(
         // Rotation detection: when a and b are the same SSA value, use RotL/RotR.
         if val_key_basic(a) == val_key_basic(b) {
             let dst = result_reg(e, instr);
-            let mut a_reg = operand_reg(e, a, TEMP1);
+            // `amt_reg` is resolved lazily below (only on the variable-amount
+            // path), so `a_reg` only needs to avoid TEMP2 — the future load
+            // target for `amt` if the constant fast-path doesn't fire.
+            let mut a_reg = operand_reg_avoiding(e, a, TEMP1, &[TEMP2]);
             if a_reg != TEMP1 && a_reg == dst {
                 a_reg = TEMP1;
             }
@@ -547,7 +550,7 @@ pub fn lower_llvm_intrinsic<'ctx>(
             }
 
             // Variable rotation amount: use the register-form rotates.
-            let mut amt_reg = operand_reg(e, amt, TEMP2);
+            let mut amt_reg = operand_reg_avoiding(e, amt, TEMP2, &[TEMP1]);
             if amt_reg != TEMP2 && amt_reg == dst {
                 amt_reg = TEMP2;
             }

--- a/crates/wasm-pvm/src/llvm_backend/memory.rs
+++ b/crates/wasm-pvm/src/llvm_backend/memory.rs
@@ -17,8 +17,8 @@ use crate::pvm::Instruction;
 use crate::{Error, Result, abi};
 
 use super::emitter::{
-    LoweringContext, PvmEmitter, get_operand, operand_reg, result_reg, result_slot,
-    try_get_constant,
+    LoweringContext, PvmEmitter, get_operand, operand_reg, operand_reg_avoiding, result_reg,
+    result_slot, try_get_constant,
 };
 use crate::abi::{TEMP_RESULT, TEMP1, TEMP2};
 
@@ -245,8 +245,8 @@ pub fn emit_pvm_store<'ctx>(
     }
 
     // Load-side coalescing for both address and value (no dst conflict — store has no dest register).
-    let addr_reg = operand_reg(e, addr, TEMP1);
-    let val_reg = operand_reg(e, val, TEMP2);
+    let addr_reg = operand_reg_avoiding(e, addr, TEMP1, &[TEMP2]);
+    let val_reg = operand_reg_avoiding(e, val, TEMP2, &[TEMP1]);
     if addr_reg == TEMP1 {
         e.load_operand(addr, TEMP1)?;
     }


### PR DESCRIPTION
## Summary

`operand_reg` previously only returned a value's allocated register from the
linear-scan map. The per-block `slot_cache` (which already powers store-load
forwarding inside `load_operand`) was untapped at this layer, so any value
transiently in `TEMP1`/`TEMP2`/`TEMP_RESULT` — or in an allocated register
whose `alloc_reg_slot` had been invalidated and reloaded elsewhere —
required a redundant `MoveReg` even though the value was already in the
cached register.

A naive extension that "also returns `slot_cache` hits" introduces a
hard-to-spot aliasing hazard at multi-operand call sites: sibling operands
(e.g. `lhs`/`rhs` in `lower_binary_arith`) use `TEMP1`/`TEMP2` as their
`load_operand` targets. If `rhs` was cached in `TEMP1`, the broader lookup
returns `TEMP1` for `rhs`; the very next `load_operand(lhs, TEMP1)` then
overwrites it — yielding `Add32 dst=r4, src1=r2, src2=r2` and computing
`5 + 5 = 10` for `add(5, 7)`.

This PR adds `operand_reg_avoiding(e, val, fallback, avoid: &[u8])`. The
broader cache lookup also rejects any cached register listed in `avoid`,
falling through to the operand's own fallback so the protective load can
populate a non-conflicting register. `operand_reg(...)` becomes a thin
wrapper that passes `&[]`. All 12 multi-operand call sites pass the OTHER
operands' load targets as `avoid`:

- `alu.rs`: binary arithmetic, bitwise-NOT fusion, icmp register-register, 4 cmov variants
- `memory.rs`: store address+value
- `intrinsics.rs`: signed/unsigned min-max, fshl/fshr rotation
- `control_flow.rs`: fused branch lhs/rhs

Single-operand callers (branch cond, switch value, rotate amounts, etc.)
keep the simple `operand_reg(...)` signature — no sibling load means no
hazard.

## Benchmarks

Comparison vs `origin/main` (full benchmark.sh output below).

### Direct execution

| Benchmark           |  Code (before) → (after) |  Code Δ |   Gas (before) → (after) |   Gas Δ |
|---------------------|--------------------------|---------|--------------------------|---------|
| add(5,7)            |             99 →     96 |  -3.0%  |             28 →     27 |  -3.6%  |
| fib(20)             |            148 →    146 |  -1.4%  |            409 →    389 |  -4.9%  |
| AS fib(10)          |            504 →    494 |  -2.0%  |            245 →    240 |  -2.0%  |
| AS factorial(7)     |            490 →    480 |  -2.0%  |            207 →    196 |  -5.3%  |
| AS gcd(2017,200)    |            517 →    507 |  -1.9%  |            174 →    166 |  -4.6%  |
| AS decoder          |          4,944 →  4,764 |  -3.6%  |            953 →    931 |  -2.3%  |
| AS array            |          4,427 →  4,256 |  -3.9%  |            820 →    796 |  -2.9%  |
| aslan-fib           |         13,369 → 12,997 |  -2.8%  |         11,475 → 10,672 |  -7.0%  |
| **anan-as compiler**|         **84,419 → 80,779** | **-4.3%** |                  n/a      |   n/a   |
| aslan-ecalli        |         28,822 → 28,286 |  -1.9%  |                 timeout   |   n/a   |
| blake2b("abc",32)   |          2,751 →  2,691 |  -2.2%  |         17,978 → 17,246 |  -4.1%  |
| sha512("abc")       |          2,559 →  2,483 |  -3.0%  |         17,981 → 16,827 |  -6.4%  |
| sha512(240×"a")     |          2,559 →  2,483 |  -3.0%  |         53,643 → 50,199 |  -6.4%  |

### PVM-in-PVM (representative of glutton-kusama workload class)

| Benchmark               |       Outer Gas (before) → (after) |     Δ   |
|-------------------------|-------------------------------------|---------|
| PiP add(5,7)            |          1,219,636 →  1,178,930     | -3.3%   |
| PiP AS fib(10)          |          1,571,744 →  1,502,052     | -4.4%   |
| PiP JAM-SDK fib(10)     |          9,584,553 →  8,860,232     | **-7.6%**   |
| PiP aslan-fib           |         15,858,666 → 14,149,227     | **-10.8%**  |
| PiP blake2b             |         16,362,407 → 14,758,861     | **-9.8%**   |
| PiP sha512(short)       |         15,544,098 → 13,817,418     | **-11.1%**  |
| PiP sha512(240×"a")     |         41,964,498 → 37,094,462     | **-11.6%**  |

## Test plan

- [x] `cargo test --release` — 36 Rust unit + 1 doc test green
- [x] `bun test layer1/` — 56 / 56 green
- [x] `bun test layer2/` — 169 / 169 green
- [x] `bun test layer3/` — 428 / 428 green
- [x] `bun test layer4/` — 6 / 6 green (PVM-in-PVM smoke)
- [x] `bun run test:differential` — 142 / 142 green
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings` (via `.githooks/pre-push`)
- [x] `./tests/utils/benchmark.sh` against `origin/main` — see tables above
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)