### PR TITLE
docs(readme): refresh stale facts (test count, version, flags)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WASM-PVM: WebAssembly to PolkaVM Recompiler
 
 > **WARNING: This project is largely vibe-coded.**
-> It was built iteratively with heavy AI assistance (Claude). While it has 412 passing integration tests and
+> It was built iteratively with heavy AI assistance (Claude). While it has 670 passing integration tests and
 > produces working PVM bytecode, the internals may contain unconventional patterns, over-engineering in some
 > places, and under-engineering in others. Use at your own risk. Contributions and proper engineering reviews
 > are very welcome!
@@ -106,7 +106,7 @@ Entry functions use a unified ABI: `main(args_ptr: i32, args_len: i32) -> i64`, 
 - **Per-block register cache**: eliminates redundant loads when a value is reused shortly after being computed (~50% gas reduction)
 - **No `unsafe` code**: `deny(unsafe_code)` enforced at workspace level
 - **No floating point**: PVM lacks FP support; WASM floats are rejected at compile time
-- **All optimizations are toggleable**: `--no-llvm-passes`, `--no-peephole`, `--no-register-cache`, `--no-icmp-fusion`, `--no-shrink-wrap`, `--no-dead-store-elim`, `--no-const-prop`, `--no-inline`, `--no-cross-block-cache`, `--no-register-alloc`, `--no-fallthrough-jumps`
+- **All optimizations are toggleable**: `--no-llvm-passes`, `--no-peephole`, `--no-register-cache`, `--no-icmp-fusion`, `--no-shrink-wrap`, `--no-dead-store-elim`, `--no-const-prop`, `--no-inline`, `--inline-threshold N`, `--no-cross-block-cache`, `--no-register-alloc`, `--no-aggressive-regalloc`, `--no-scratch-reg-alloc`, `--no-caller-saved-alloc`, `--no-lazy-spill`, `--no-dead-function-elim`, `--no-fallthrough-jumps`, `--no-libcall-recognition`
 
 ### Benchmark: Optimizations Impact
 
@@ -191,7 +191,15 @@ wasm-pvm compile input.wasm -o output.jam \
   --no-llvm-passes --no-peephole --no-register-cache \
   --no-icmp-fusion --no-shrink-wrap --no-dead-store-elim \
   --no-const-prop --no-inline --no-cross-block-cache \
-  --no-register-alloc
+  --no-register-alloc --no-aggressive-regalloc \
+  --no-scratch-reg-alloc --no-caller-saved-alloc \
+  --no-lazy-spill --no-dead-function-elim \
+  --no-fallthrough-jumps --no-libcall-recognition
+
+# Compile past the "float wall" by replacing every f32/f64 op
+# with a runtime trap (useful for discovering other unsupported
+# features in a module before adding real FP support)
+wasm-pvm compile input.wasm -o output.jam --trap-floats
 ```
 
 See the [Import Handling](#import-handling) section for details on resolving WASM imports.
@@ -202,10 +210,10 @@ The `wasm-pvm` crate can be used as a Rust dependency. It supports two modes:
 
 ```toml
 # Full compiler (default) — requires LLVM 18
-wasm-pvm = "0.5.2"
+wasm-pvm = "0.9.0"
 
 # PVM types only — no LLVM dependency, compiles to wasm32-unknown-unknown
-wasm-pvm = { version = "0.5.2", default-features = false }
+wasm-pvm = { version = "0.9.0", default-features = false }
 ```
 
 With `default-features = false`, only the PVM type definitions are available: `Instruction`, `Opcode`, `ProgramBlob`, `SpiProgram`, `abi::*`, `memory_layout::*`, and `Error`. This is useful for downstream tools that need to work with PVM bytecode (interpreters, debuggers, analyzers) without requiring the full LLVM compiler toolchain.
@@ -229,7 +237,7 @@ crates/
       llvm_backend/      # LLVM IR → PVM bytecode lowering (feature = "compiler")
       translate/         # Compilation orchestration & SPI assembly (feature = "compiler")
   wasm-pvm-cli/          # Command-line interface
-tests/                   # 412 integration tests (TypeScript/Bun)
+tests/                   # 670 integration tests (TypeScript/Bun)
   fixtures/
     wat/                 # WAT test programs
     assembly/            # AssemblyScript examples
@@ -256,10 +264,11 @@ cd tests && bun test layer1/
 
 The test suite is organized into layers:
 
-- **Layer 1**: Core/smoke tests (~50 tests) — fast, run during development
-- **Layer 2**: Feature tests (~140 tests)
-- **Layer 3**: Regression/edge cases (~220 tests)
+- **Layer 1**: Core/smoke tests (~56 tests) — fast, run during development
+- **Layer 2**: Feature tests (~169 tests)
+- **Layer 3**: Regression/edge cases (~445 tests)
 - **Layer 4-5**: PVM-in-PVM tests — the PVM interpreter itself compiled to PVM, running the test suite inside PVM
+- **Differential** (~142 tests): cross-checks PVM output against Bun's native WebAssembly engine; run with `bun run test:differential`
 
 ## Import Handling
 


### PR DESCRIPTION
## Summary

The README had drifted behind the codebase since 0.5.2. This PR refreshes only the parts that go stale without warning — no code changes.

- **Integration test count**: `412` → `670` (verified via `bun test layer{1,2,3}/`). Per-layer breakdown updated (`~50/~140/~220` → `~56/~169/~445`).
- **Differential tests**: added a row (`~142 tests`) — the suite was previously undocumented in the README.
- **Crate version** in Cargo.toml examples: `0.5.2` → `0.9.0` (matches the workspace).
- **Optimization flag list**: 11 of 18 → **all 18**. Added `--inline-threshold N`, `--no-aggressive-regalloc`, `--no-scratch-reg-alloc`, `--no-caller-saved-alloc`, `--no-lazy-spill`, `--no-dead-function-elim`, `--no-libcall-recognition`. Same fix applied to the "disable all optimizations" CLI example.
- **`--trap-floats`**: brief CLI example added (introduced in #210, previously undocumented).

## Benchmarks

Re-ran `./tests/utils/benchmark.sh` against current `main` on a clean tree (with `vendor/anan-as` initialized + built). **Every JAM size, code size, and gas number in both tables matched the committed README byte-for-byte**, so the benchmark tables are intentionally unchanged.

Benchmark comparison (main vs td-readme-refresh): identical numbers; no diff to paste.

## Test plan

- [x] `bun test layer{1,2,3}/` — 670 pass / 0 fail (also re-verified by pre-push hook on push)
- [x] `./tests/utils/benchmark.sh` matches existing tables byte-for-byte
- [x] Cross-checked CLI flags against `crates/wasm-pvm-cli/src/main.rs` (all 18 `no_*` + `inline_threshold` + `trap_floats`)
- [x] Version cross-checked against root `Cargo.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)