### PR TITLE
fix(benchmark): drop --no-llvm-passes from NO_OPT_FLAGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Entry functions use a unified ABI: `main(args_ptr: i32, args_len: i32) -> i64`, 
 - **Per-block register cache**: eliminates redundant loads when a value is reused shortly after being computed (~50% gas reduction)
 - **No `unsafe` code**: `deny(unsafe_code)` enforced at workspace level
 - **No floating point**: PVM lacks FP support; WASM floats are rejected at compile time
-- **All optimizations are toggleable**: `--no-llvm-passes`, `--no-peephole`, `--no-register-cache`, `--no-icmp-fusion`, `--no-shrink-wrap`, `--no-dead-store-elim`, `--no-const-prop`, `--no-inline`, `--inline-threshold N`, `--no-cross-block-cache`, `--no-register-alloc`, `--no-aggressive-regalloc`, `--no-scratch-reg-alloc`, `--no-caller-saved-alloc`, `--no-lazy-spill`, `--no-fallthrough-jumps`, `--no-libcall-recognition`
+- **All optimizations are toggleable**: `--no-peephole`, `--no-register-cache`, `--no-icmp-fusion`, `--no-shrink-wrap`, `--no-dead-store-elim`, `--no-const-prop`, `--no-inline`, `--inline-threshold N`, `--no-cross-block-cache`, `--no-register-alloc`, `--no-aggressive-regalloc`, `--no-scratch-reg-alloc`, `--no-caller-saved-alloc`, `--no-lazy-spill`, `--no-fallthrough-jumps`, `--no-libcall-recognition`. (`--no-llvm-passes` also exists but is debug-only — disabling `mem2reg` breaks PVM lowering; see `docs/src/optimizations.md`.)
 
 ### Benchmark: Optimizations Impact
 
@@ -190,9 +190,10 @@ wasm-pvm compile input.wasm -o output.jam \
 # Disable specific optimizations
 wasm-pvm compile input.wasm -o output.jam --no-inline --no-peephole
 
-# Disable all optimizations
+# Disable all optimizations. `--no-llvm-passes` is omitted on purpose:
+# disabling `mem2reg` breaks PVM lowering on any non-trivial input.
 wasm-pvm compile input.wasm -o output.jam \
-  --no-llvm-passes --no-peephole --no-register-cache \
+  --no-peephole --no-register-cache \
   --no-icmp-fusion --no-shrink-wrap --no-dead-store-elim \
   --no-const-prop --no-inline --no-cross-block-cache \
   --no-register-alloc --no-aggressive-regalloc \

--- a/crates/wasm-pvm-cli/src/main.rs
+++ b/crates/wasm-pvm-cli/src/main.rs
@@ -49,7 +49,12 @@ enum Commands {
         #[arg(long, help = "Output stats as JSON instead of text")]
         json: bool,
 
-        #[arg(long, help = "Disable LLVM optimization passes")]
+        #[arg(
+            long,
+            help = "DEBUG ONLY: skip the entire LLVM pass pipeline including mem2reg. \
+                    The PVM backend cannot lower alloca / unpromoted SSA, so any non-trivial \
+                    WASM will fail to compile. Use to inspect raw frontend IR."
+        )]
         no_llvm_passes: bool,
 
         #[arg(long, help = "Disable peephole optimizer")]

--- a/docs/src/cli-usage.md
+++ b/docs/src/cli-usage.md
@@ -15,11 +15,13 @@ wasm-pvm compile input.wasm -o output.jam --no-inline --no-peephole
 
 # Disable all optimizations
 wasm-pvm compile input.wasm -o output.jam \
-  --no-llvm-passes --no-peephole --no-register-cache \
+  --no-peephole --no-register-cache \
   --no-icmp-fusion --no-shrink-wrap --no-dead-store-elim \
   --no-const-prop --no-inline --no-cross-block-cache \
   --no-register-alloc --no-fallthrough-jumps
 ```
+
+`--no-llvm-passes` is **not** included above: it disables `mem2reg` and therefore breaks PVM lowering on any non-trivial input. See [Diagnostic & Triage Flags](#diagnostic--triage-flags).
 
 ## Optimization Flags
 
@@ -27,7 +29,6 @@ All non-trivial optimizations are enabled by default. Each can be individually d
 
 | Flag | What it controls |
 |------|------------------|
-| `--no-llvm-passes` | LLVM optimization passes (mem2reg, instcombine, etc.) |
 | `--no-peephole` | Post-codegen peephole optimizer |
 | `--no-register-cache` | Per-block store-load forwarding |
 | `--no-icmp-fusion` | Fuse ICmp+Branch into single PVM branch |
@@ -49,6 +50,7 @@ are *not* optimizations.
 | Flag | What it does |
 |------|--------------|
 | `--trap-floats` | Replace every f32/f64 operator with a runtime trap instead of failing compilation. See [Trap Floats Mode](./trap-floats.md). |
+| `--no-llvm-passes` | **Debug only.** Skip the entire LLVM pass pipeline (including `mem2reg`). The PVM backend cannot lower the resulting `alloca` / unpromoted SSA, so non-trivial WASM will fail to compile. Use only to inspect raw frontend IR. |
 
 When compilation fails on an unsupported operator, the error message includes
 the function index, the function's display name (from the WASM `name` custom

--- a/docs/src/optimizations.md
+++ b/docs/src/optimizations.md
@@ -2,13 +2,24 @@
 
 All non-trivial optimizations can be individually toggled via `OptimizationFlags` (in `translate/mod.rs`, re-exported from `lib.rs`). Each defaults to enabled; CLI exposes `--no-*` flags.
 
-## LLVM Passes (`--no-llvm-passes`)
+## LLVM Pass Pipeline
 
-Four-phase optimization pipeline:
+Four phases run on every compile. The whole pipeline is gated by the `llvm_passes` flag (CLI `--no-llvm-passes`); the inlining and mergefunc phases also have individual toggles.
+
 1. `mem2reg`, `instcombine`, `simplifycfg` (pre-inline cleanup)
 2. `cgscc(inline)` (optional, see `--no-inline`)
 3. `instcombine<max-iterations=20>`, `simplifycfg`, `gvn`, `simplifycfg`, `dce`
 4. `mergefunc` (optional, see `--no-mergefunc`)
+
+### `--no-llvm-passes` (debug only)
+
+**Not a tunable optimization.** This flag skips the *entire* pipeline above, including `mem2reg`. The PVM backend cannot lower `alloca` / unpromoted SSA — every input non-trivial enough to use locals (i.e. virtually every real WASM module) fails with:
+
+```text
+Error: Unsupported WASM feature: LLVM opcode Alloca (in function #N during PVM lowering)
+```
+
+Per the `experiments/opt_impact.sh` sweep, **31 of 31 representative inputs** (fixture WATs, AS-built WASM, polkadot runtimes) fail to compile with this flag set. Use only to inspect the raw frontend IR (`--verbose` / dumps) before any optimization runs. Do not include it in `--no-opt` bundles or treat it as comparable to `--no-peephole`, `--no-register-cache`, etc.
 
 ## Function Inlining (`--no-inline`)
 

--- a/experiments/analysis.md
+++ b/experiments/analysis.md
@@ -41,7 +41,7 @@ Total: 13 + 0 + 3 + 1 + 14 = **31 inputs**.
 
 1. ~~**`dead_function_elimination`** never fires on any of the 31 inputs.~~ Removed in #244 — the pass was correct but redundant with upstream tooling (AssemblyScript tree-shaking, wasm-opt, Substrate's runtime build).
 
-2. **`--no-llvm-passes` in `NO_OPT_FLAGS`** (`tests/utils/benchmark.sh:30`) silently breaks every non-trivial benchmark under `--no-opt`, because mem2reg is mandatory for the PVM backend (alloca lowering isn't implemented). Remove from the bulk-disable array and document the flag as a frontend-debugging escape hatch, not a tunable optimization. Tracked in #245.
+2. ~~**`--no-llvm-passes` in `NO_OPT_FLAGS`** (`tests/utils/benchmark.sh:30`) silently breaks every non-trivial benchmark under `--no-opt`, because mem2reg is mandatory for the PVM backend (alloca lowering isn't implemented). Remove from the bulk-disable array and document the flag as a frontend-debugging escape hatch, not a tunable optimization.~~ Fixed in #245 — flag removed from `NO_OPT_FLAGS`, documented as debug-only in `docs/src/optimizations.md` and `docs/src/cli-usage.md`.
 
 3. **Noisy / net-negative-on-subsets** — `shrink_wrap_callee_saves`, `inlining` (default threshold), `aggressive_register_allocation`, `caller_saved_alloc`, `libcall_recognition`. JAM size alone can't decide their fate because some of them trade size for gas. Re-measure with gas usage on the dynamic fixtures (everything in `BENCHMARKS` with non-empty `args`) before deciding to keep, tune, or remove. Tracked in #246.
 

--- a/tests/utils/benchmark.sh
+++ b/tests/utils/benchmark.sh
@@ -282,7 +282,11 @@ compile_noopt_jams() {
       continue
     fi
     local output="$noopt_dir/$basename.jam"
-    compile_benchmark "$wasm_src" "$output" "$basename" "${NO_OPT_FLAGS[@]}" >&2
+    # Tolerate per-fixture compile failures (missing source, missing
+    # vendor/anan-as build, etc.) so one bad entry doesn't kill the whole
+    # table under `set -e`. `benchmark_one` renders SKIP rows for missing
+    # JAMs, matching the polkadot path's `|| rc=$?` tolerance.
+    compile_benchmark "$wasm_src" "$output" "$basename" "${NO_OPT_FLAGS[@]}" >&2 || true
   done
   compile_polkadot_jams "$noopt_dir" "${NO_OPT_FLAGS[@]}"
 }

--- a/tests/utils/benchmark.sh
+++ b/tests/utils/benchmark.sh
@@ -27,8 +27,12 @@ JAM_DIR=""
 COMPILER_JAM=""
 NO_OPT=false
 
+# Tunable optimizations only. `--no-llvm-passes` is intentionally NOT in this
+# list: it disables the entire LLVM pass pipeline including `mem2reg`, which
+# the PVM backend requires (otherwise IR retains `alloca` and lowering fails
+# with `Unsupported WASM feature: LLVM opcode Alloca`). It is a frontend
+# debugging escape hatch, not an optimization toggle.
 NO_OPT_FLAGS=(
-  --no-llvm-passes
   --no-peephole
   --no-register-cache
   --no-icmp-fusion
@@ -295,7 +299,7 @@ polkadot_timeout_bin() {
 # trap-all import map. Silently does nothing when no WASMs are present so a
 # fresh clone benchmarks cleanly. `extra_flags` (optional) are forwarded to
 # `wasm-pvm compile` after `--trap-floats`, so the no-opt mode can pass the
-# usual `--no-llvm-passes` etc.
+# usual `--no-peephole` etc.
 compile_polkadot_jams() {
   local out_dir="$1"
   shift


### PR DESCRIPTION
Closes #245.

## Summary

- `--no-llvm-passes` disables the entire LLVM pipeline including `mem2reg`, so every non-trivial WASM fails to lower (`Unsupported WASM feature: LLVM opcode Alloca`). Per #243 it failed **31/31** representative inputs. Removed from `NO_OPT_FLAGS` in `tests/utils/benchmark.sh` so `--no-opt` no longer produces a silently-broken baseline.
- Reframed the flag as a **debug-only** escape hatch across `docs/src/optimizations.md`, `docs/src/cli-usage.md` (moved to *Diagnostic & Triage Flags*), `README.md`, and the CLI `--help` text. Optional rename (`--debug-skip-llvm-passes`) deferred per the issue.
- Drive-by: `compile_noopt_jams` was dying under `set -e` whenever any fixture source was missing (e.g. fresh-clone `vendor/anan-as/dist/build/compiler.wasm`). Added `|| true` to mirror `compile_polkadot_jams`'s tolerance — `benchmark_one` already renders SKIP rows for missing JAMs.

No codegen changes — default-build benchmark output is byte-identical to `main`.

## Verification

Per the issue's "how to verify" section:

```bash
./tests/utils/benchmark.sh --no-opt    # populated table for every benchmark — now works (output below)
```

Before this PR: every non-trivial entry collapsed at compile time with `Unsupported WASM feature: LLVM opcode Alloca`, the `compile_noopt_jams` loop died under `set -e`, and the eventual table was empty / SKIP for any input with locals.

After this PR (`--no-opt`):

| Benchmark | WASM Size | JAM Size | Code Size | Gas Used | Time (median of 3) |
|-----------|-----------|----------|-----------|----------|-------------------|
| add(5,7)             |         68 |        229 |        156 |         47 |       75ms |
| fib(20)              |        110 |        282 |        198 |        737 |       72ms |
| factorial(10)        |        102 |        256 |        175 |        324 |       73ms |
| is_prime(25)         |        162 |        381 |        287 |        100 |       73ms |
| AS fib(10)           |        235 |        842 |        691 |        400 |       73ms |
| AS factorial(7)      |        234 |        831 |        681 |        343 |       73ms |
| AS gcd(2017,200)     |        229 |        861 |        713 |        258 |       74ms |
| AS decoder           |       1537 |       8588 |       6464 |       1961 |       76ms |
| AS array             |       1405 |       7652 |       5655 |       1651 |       74ms |
| regalloc two loops(500) |        252 |        769 |        623 |      54087 |       83ms |
| aslan-fib accumulate |          - |      26277 |      17883 |      15977 |       80ms |
| host-call-log        |        171 |        476 |        120 |         44 |       73ms |
| anan-as PVM interpreter |      54641 |     160074 |     121287 |          - |          - |
| aslan-ecalli accumulate |          - |      52155 |      35883 |      12415 |       81ms |
| blake2b("abc",32)    |       1193 |       4735 |       3348 |      21539 |       78ms |
| sha512("abc")        |       1790 |       4758 |       3379 |      23936 |       76ms |
| u128 mul x1000       |        296 |        553 |        427 |      92041 |       86ms |
| u128 div(fast) x1000 |        273 |        959 |        778 |      92041 |       86ms |
| u128 div(slow) x1000 |        273 |        965 |        779 |     171041 |       98ms |
| sha512(240x"a" — multi-block + two-pad) |       1790 |       4758 |       3379 |      71060 |       86ms |

The previously-broken inputs (every WAT with locals, every AS-built WASM, the anan-as compiler itself) now produce real numbers.

```bash
./target/release/wasm-pvm compile tests/fixtures/wat/fibonacci.jam.wat -o /tmp/fib.jam --no-llvm-passes
# → Error: Unsupported WASM feature: LLVM opcode Alloca (in function #0 'main' during PVM lowering)
```

The flag itself still fails on non-trivial inputs — that's the documented debug-only behavior. The `experiments/results/deltas.csv` "31 failed" rows from #243 remain valid.

### Standard `--base/--current` benchmark

This PR touches docs, the no-opt-bundle script config, and the CLI help text — no codegen path is modified. A `./tests/utils/benchmark.sh --base main --current td-issue-245` comparison would show all-zero deltas. Skipped to save ~30 min of redundant CI; happy to run it if a reviewer wants the artifact.

## Follow-ups (out of scope, suggested as separate issues)

1. **CI smoke check for `benchmark.sh --no-opt`** — the script's silence-on-missing-fixture under `set -e` is what let this bug hide for so long. A trimmed smoke variant (skip polkadot + PVM-in-PVM) would catch regressions in <2 min.
2. **Optional rename** `--no-llvm-passes` → `--debug-skip-llvm-passes` for stronger discoverability. Deferred per the issue (breaking for downstream users).

## Test plan

- [x] `bash -n tests/utils/benchmark.sh` passes
- [x] `cargo build --release` succeeds; updated `--help` text appears for `--no-llvm-passes`
- [x] `cargo test --release` — 36/36 + 36/36 unit tests pass
- [x] `wasm-pvm compile fibonacci.jam.wat --no-llvm-passes` still fails with the documented `Alloca` error (confirms the flag itself is unchanged)
- [x] `./tests/utils/benchmark.sh --no-opt` produces a populated table for every fixture that built (output above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)