### PR TITLE
ci: smoke-check benchmark.sh --no-opt to catch silent regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,14 @@ jobs:
       - name: Build test artifacts
         run: cd tests && bun build.ts
 
+      - name: Benchmark no-opt smoke check
+        env:
+          BENCHMARK_SKIP_POLKADOT: "1"
+          BENCHMARK_SKIP_PVM_IN_PVM: "1"
+        run: |
+          ./tests/utils/benchmark.sh --no-opt 2>/dev/null \
+            | awk '/^\| / && /SKIP/ { print; bad=1 } END { exit bad }'
+
       - name: Run integration tests (layers 1-3)
         run: cd tests && bun test layer1/ layer2/ layer3/
 

--- a/tests/utils/benchmark.sh
+++ b/tests/utils/benchmark.sh
@@ -105,6 +105,12 @@ POLKADOT_RUNTIMES=(
 # branch comparisons bounded.
 POLKADOT_COMPILE_TIMEOUT="${POLKADOT_COMPILE_TIMEOUT:-300}"
 
+# CI smoke-check opt-outs (issue #250). Set to "1" to skip the corresponding
+# section entirely. Used by the `--no-opt` smoke check in CI to keep runtime
+# bounded while still exercising the direct-execution path.
+BENCHMARK_SKIP_POLKADOT="${BENCHMARK_SKIP_POLKADOT:-0}"
+BENCHMARK_SKIP_PVM_IN_PVM="${BENCHMARK_SKIP_PVM_IN_PVM:-0}"
+
 # Polkadot runtimes do not get one row per benchmark — that's 14 long-name rows
 # of large numbers that drown out the rest of the suite. Instead, after the
 # standard `BENCHMARKS` loop finishes, `polkadot_summary_row` emits a single
@@ -288,7 +294,11 @@ compile_noopt_jams() {
     # JAMs, matching the polkadot path's `|| rc=$?` tolerance.
     compile_benchmark "$wasm_src" "$output" "$basename" "${NO_OPT_FLAGS[@]}" >&2 || true
   done
-  compile_polkadot_jams "$noopt_dir" "${NO_OPT_FLAGS[@]}"
+  if [ "$BENCHMARK_SKIP_POLKADOT" = "1" ]; then
+    echo "Skipping Polkadot section (BENCHMARK_SKIP_POLKADOT=1)" >&2
+  else
+    compile_polkadot_jams "$noopt_dir" "${NO_OPT_FLAGS[@]}"
+  fi
 }
 
 # Resolve a `timeout` binary or empty string if none is available.
@@ -616,11 +626,15 @@ run_benchmarks() {
       printf "| %-20s | %10s | %10s | %10s | %10s | %10s |\n" "$rdesc" "$wsize" "SKIP" "-" "-" "-"
     fi
   done
-  polkadot_summary_row
+  if [ "$BENCHMARK_SKIP_POLKADOT" != "1" ]; then
+    polkadot_summary_row
+  fi
   echo ""
 
   # PVM-in-PVM benchmarks
-  if [ -f "$COMPILER_JAM" ]; then
+  if [ "$BENCHMARK_SKIP_PVM_IN_PVM" = "1" ]; then
+    echo "Skipping PVM-in-PVM section (BENCHMARK_SKIP_PVM_IN_PVM=1)" >&2
+  elif [ -f "$COMPILER_JAM" ]; then
     echo "### PVM-in-PVM"
     echo ""
     echo "| Benchmark | JAM Size | Code Size | Outer Gas Used | Time (median of 3) |"
@@ -690,10 +704,14 @@ build_and_benchmark() {
   else
     JAM_DIR="$DEFAULT_JAM_DIR"
     COMPILER_JAM="$DEFAULT_JAM_DIR/anan-as-compiler.jam"
-    # `bun build.ts` only knows about the standard fixtures, so compile the
-    # populated Polkadot runtimes (if any) into the same JAM dir using the
-    # current toolchain. Silently no-ops if WASMs aren't present.
-    compile_polkadot_jams "$JAM_DIR"
+    if [ "$BENCHMARK_SKIP_POLKADOT" = "1" ]; then
+      echo "Skipping Polkadot section (BENCHMARK_SKIP_POLKADOT=1)" >&2
+    else
+      # `bun build.ts` only knows about the standard fixtures, so compile the
+      # populated Polkadot runtimes (if any) into the same JAM dir using the
+      # current toolchain. Silently no-ops if WASMs aren't present.
+      compile_polkadot_jams "$JAM_DIR"
+    fi
   fi
 
   run_benchmarks "$label"


### PR DESCRIPTION
Closes #250.

## Summary

- Adds `BENCHMARK_SKIP_POLKADOT` and `BENCHMARK_SKIP_PVM_IN_PVM` env vars to `tests/utils/benchmark.sh` (default `0`). Each guards the corresponding section and emits a short stderr message when skipped.
- Wires a new "Benchmark no-opt smoke check" step into the `integration` job that runs `benchmark.sh --no-opt` with both vars set and asserts (via awk) that the direct-execution table has zero `SKIP` rows.

## Why

#245 fixed a silent failure where `--no-opt` had been producing an empty baseline because `--no-llvm-passes` was in `NO_OPT_FLAGS` and `compile_noopt_jams` died mid-loop under `set -e`. Nothing exercises that path in CI today, so analogous breakage would also slip through. This step makes such regressions loud.

## Design notes

- `BENCHMARK_SKIP_POLKADOT` is mostly cosmetic in CI today (`examples/polkadot/wasm/` is unpopulated, so `compile_polkadot_jams` and `polkadot_summary_row` already no-op silently). Still explicit so the smoke step short-circuits if someone populates them locally.
- `BENCHMARK_SKIP_PVM_IN_PVM` is the load-bearing one: skips ~12 `node anan-as run`x3 invocations and keeps the smoke step bounded.
- The awk one-liner relies on GitHub's default `bash -eo pipefail` shell so a mid-script crash in `benchmark.sh` propagates through the pipe rather than being masked by awk's exit code.

## Test plan

- [ ] CI integration job's new "Benchmark no-opt smoke check" step succeeds.
- [ ] Step fails (locally) if a fixture compile is broken — e.g. revert #245 to put `--no-llvm-passes` back in `NO_OPT_FLAGS` and confirm the awk assertion catches the SKIP rows.

## Benchmark results

No bytecode/codegen changes — this PR only touches `benchmark.sh` (CI plumbing) and `.github/workflows/ci.yml`. JAM size / gas / time tables are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)