### PR TITLE
refactor(backend): use insertion-order IDs for ValKey

### DIFF
--- a/crates/wasm-pvm/src/llvm_backend/control_flow.rs
+++ b/crates/wasm-pvm/src/llvm_backend/control_flow.rs
@@ -22,7 +22,7 @@ use crate::{Error, Result, abi};
 
 use super::emitter::{
     PvmEmitter, SCRATCH1, SCRATCH2, get_bb_operand, get_operand, has_phi_from, operand_reg,
-    operand_reg_avoiding, result_slot, try_get_constant, val_key_basic, val_key_instr,
+    operand_reg_avoiding, result_slot, try_get_constant,
 };
 use crate::abi::{STACK_PTR_REG, TEMP_RESULT, TEMP1, TEMP2};
 
@@ -430,7 +430,7 @@ pub fn emit_phi_copies<'ctx>(
             break;
         }
         let phi_slot = result_slot(e, instr)?;
-        let phi_key = val_key_instr(instr);
+        let phi_key = e.val_key_instr(instr);
         let phi_reg = e.regalloc.val_to_reg.get(&phi_key).copied();
 
         let phi: PhiValue<'ctx> = instr
@@ -470,7 +470,7 @@ pub fn emit_phi_copies<'ctx>(
 /// Get the valid allocated register for an incoming value, if any.
 /// Returns None if the value is a constant, has no allocation, or the
 /// register doesn't currently hold the right slot.
-fn get_valid_alloc_reg(e: &PvmEmitter<'_>, value: BasicValueEnum<'_>) -> Option<u8> {
+fn get_valid_alloc_reg(e: &mut PvmEmitter<'_>, value: BasicValueEnum<'_>) -> Option<u8> {
     if let BasicValueEnum::IntValue(iv) = value {
         // Constants don't have allocated registers.
         if iv.get_sign_extended_constant().is_some() || iv.get_zero_extended_constant().is_some() {
@@ -479,7 +479,7 @@ fn get_valid_alloc_reg(e: &PvmEmitter<'_>, value: BasicValueEnum<'_>) -> Option<
         if iv.is_poison() || iv.is_undef() {
             return None;
         }
-        let key = val_key_basic(value);
+        let key = e.val_key_basic(value);
         if let Some(&alloc_reg) = e.regalloc.val_to_reg.get(&key) {
             let slot = e.get_slot(key)?;
             if e.is_alloc_reg_valid(alloc_reg, slot) {
@@ -632,7 +632,7 @@ fn emit_phi_copies_regaware<'ctx>(
             && src_reg == phi_reg
             && !(scratch_might_be_temps && (src_reg == SCRATCH1 || src_reg == SCRATCH2))
         {
-            let key = val_key_basic(copy.incoming_value);
+            let key = e.val_key_basic(copy.incoming_value);
             if let Some(slot) = e.get_slot(key)
                 && e.is_alloc_reg_valid(src_reg, slot)
             {
@@ -782,7 +782,7 @@ fn emit_phi_copies_via_slots<'ctx>(
             const_copies.push((copy.phi_slot, copy.incoming_value));
             continue;
         }
-        let key = val_key_basic(copy.incoming_value);
+        let key = e.val_key_basic(copy.incoming_value);
         let src_slot = e
             .get_slot(key)
             .ok_or_else(|| Error::Internal("phi incoming value has no slot".into()))?;

--- a/crates/wasm-pvm/src/llvm_backend/emitter.rs
+++ b/crates/wasm-pvm/src/llvm_backend/emitter.rs
@@ -184,6 +184,10 @@ pub struct PvmEmitter<'ctx> {
     /// LLVM int values (params + instruction results) → stack slot offset from SP.
     pub(crate) value_slots: BTreeMap<ValKey, i32>,
 
+    /// Per-function cache mapping LLVM value pointers to stable [`ValKey`] IDs.
+    /// Populated during `pre_scan_function` and the emit/regalloc phases.
+    pub(crate) val_key_cache: ValKeyCache,
+
     /// Next available slot offset (bump allocator, starts after frame header).
     pub(crate) next_slot_offset: i32,
 
@@ -308,30 +312,53 @@ pub struct FusedIcmp<'ctx> {
     pub rhs: BasicValueEnum<'ctx>,
 }
 
-/// Wrapper key for LLVM values in the slot map.
-/// Uses the raw LLVM value pointer cast to usize.
+/// Stable, per-function identifier for an LLVM SSA value.
 ///
-/// Reproducibility warning: the derived `Ord` compares raw pointer addresses.
-/// LLVM allocates different `Value` subclasses from separate arenas whose base
-/// addresses are randomised by ASLR, so the relative order of two `ValKey`s
-/// can flip between process invocations. Do **not** rely on `BTreeMap<ValKey, _>`
-/// iteration order for anything whose side effects reach the emitted bytes.
-/// Iterate by a derived in-process-stable key instead — e.g. sort by the bump-
-/// allocated slot offset (`value_slots`) or linearised instruction index
-/// (`instr_index`).
+/// The inner `u32` is an insertion-order ID assigned by [`ValKeyCache`] the
+/// first time the value is observed during a function lowering. Two LLVM
+/// pointers that refer to the same value share the same `ValKey`; the assigned
+/// IDs are dense and monotonically increasing, so deriving `Ord` is safe and
+/// reproducible across runs (no ASLR / arena-address dependency).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct ValKey(pub(crate) usize);
+pub struct ValKey(pub(crate) u32);
 
-pub fn val_key_int(val: IntValue<'_>) -> ValKey {
-    ValKey(val.as_value_ref() as usize)
+/// Per-function cache mapping LLVM value pointers to stable insertion-order
+/// [`ValKey`] IDs. Reset to empty for each function so IDs are determined
+/// purely by IR-walking order, which is deterministic across runs.
+#[derive(Debug, Default)]
+pub struct ValKeyCache {
+    map: BTreeMap<usize, ValKey>,
+    next_id: u32,
 }
 
-pub fn val_key_basic(val: BasicValueEnum<'_>) -> ValKey {
-    ValKey(val.as_value_ref() as usize)
+impl ValKeyCache {
+    /// Look up the `ValKey` for the given LLVM value pointer, assigning a new
+    /// one on first observation. The assignment order is determined by the
+    /// caller's IR-walking order.
+    pub fn get_or_insert(&mut self, ptr: usize) -> ValKey {
+        if let Some(&key) = self.map.get(&ptr) {
+            return key;
+        }
+        let key = ValKey(self.next_id);
+        self.next_id = self
+            .next_id
+            .checked_add(1)
+            .expect("ValKeyCache: ran out of 32-bit IDs (per-function limit)");
+        self.map.insert(ptr, key);
+        key
+    }
 }
 
-pub fn val_key_instr(val: InstructionValue<'_>) -> ValKey {
-    ValKey(val.as_value_ref() as usize)
+pub fn val_key_int(cache: &mut ValKeyCache, val: IntValue<'_>) -> ValKey {
+    cache.get_or_insert(val.as_value_ref() as usize)
+}
+
+pub fn val_key_basic(cache: &mut ValKeyCache, val: BasicValueEnum<'_>) -> ValKey {
+    cache.get_or_insert(val.as_value_ref() as usize)
+}
+
+pub fn val_key_instr(cache: &mut ValKeyCache, val: InstructionValue<'_>) -> ValKey {
+    cache.get_or_insert(val.as_value_ref() as usize)
 }
 
 impl<'ctx> PvmEmitter<'ctx> {
@@ -343,6 +370,7 @@ impl<'ctx> PvmEmitter<'ctx> {
             fixups: Vec::new(),
             block_labels: HashMap::new(),
             value_slots: BTreeMap::new(),
+            val_key_cache: ValKeyCache::default(),
             next_slot_offset: FRAME_HEADER_SIZE,
             frame_size: 0,
             call_fixups: Vec::new(),
@@ -364,6 +392,21 @@ impl<'ctx> PvmEmitter<'ctx> {
             regalloc_usage: RegAllocUsageStats::default(),
             next_block_label: None,
         }
+    }
+
+    /// Convenience: look up the `ValKey` for an `IntValue` via the emitter's cache.
+    pub fn val_key_int(&mut self, val: IntValue<'_>) -> ValKey {
+        val_key_int(&mut self.val_key_cache, val)
+    }
+
+    /// Convenience: look up the `ValKey` for a `BasicValueEnum` via the emitter's cache.
+    pub fn val_key_basic(&mut self, val: BasicValueEnum<'_>) -> ValKey {
+        val_key_basic(&mut self.val_key_cache, val)
+    }
+
+    /// Convenience: look up the `ValKey` for an `InstructionValue` via the emitter's cache.
+    pub fn val_key_instr(&mut self, val: InstructionValue<'_>) -> ValKey {
+        val_key_instr(&mut self.val_key_cache, val)
     }
 
     /// Allocate a call return address (jump table address) for a direct call site.
@@ -663,7 +706,7 @@ impl<'ctx> PvmEmitter<'ctx> {
     pub fn load_operand(&mut self, val: BasicValueEnum<'ctx>, temp_reg: u8) -> Result<()> {
         match val {
             BasicValueEnum::IntValue(iv) => {
-                let key = val_key_int(iv);
+                let key = self.val_key_int(iv);
                 if let Some(signed_val) = iv.get_sign_extended_constant() {
                     self.emit_const_to_reg(temp_reg, signed_val as u64);
                 } else if let Some(const_val) = iv.get_zero_extended_constant() {
@@ -737,7 +780,7 @@ impl<'ctx> PvmEmitter<'ctx> {
                 } else {
                     return Err(Error::Internal(format!(
                         "no slot for int value {:?} (opcode: {:?})",
-                        val_key_int(iv),
+                        key,
                         iv.as_instruction().map(InstructionValue::get_opcode),
                     )));
                 }
@@ -1161,8 +1204,8 @@ pub fn get_bb_operand(instr: InstructionValue<'_>, i: u32) -> Result<BasicBlock<
 }
 
 /// Get the slot offset for an instruction's result.
-pub fn result_slot(e: &PvmEmitter<'_>, instr: InstructionValue<'_>) -> Result<i32> {
-    let key = val_key_instr(instr);
+pub fn result_slot(e: &mut PvmEmitter<'_>, instr: InstructionValue<'_>) -> Result<i32> {
+    let key = e.val_key_instr(instr);
     e.get_slot(key)
         .ok_or_else(|| Error::Internal(format!("no slot for {:?} result", instr.get_opcode())))
 }
@@ -1171,15 +1214,15 @@ pub fn result_slot(e: &PvmEmitter<'_>, instr: InstructionValue<'_>) -> Result<i3
 /// Returns the allocated register (for store-side coalescing) or `TEMP_RESULT` as fallback.
 /// When the result has an allocated register, computing directly into it avoids a
 /// subsequent `MoveReg` in `store_to_slot`.
-pub fn result_reg(e: &PvmEmitter<'_>, instr: InstructionValue<'_>) -> u8 {
+pub fn result_reg(e: &mut PvmEmitter<'_>, instr: InstructionValue<'_>) -> u8 {
     result_reg_or(e, instr, crate::abi::TEMP_RESULT)
 }
 
 /// Like `result_reg` but with a custom fallback register.
 /// Used by lowering paths that naturally use a different working register
 /// (e.g., zext/sext/trunc use `TEMP1` instead of `TEMP_RESULT`).
-pub fn result_reg_or(e: &PvmEmitter<'_>, instr: InstructionValue<'_>, fallback: u8) -> u8 {
-    let key = val_key_instr(instr);
+pub fn result_reg_or(e: &mut PvmEmitter<'_>, instr: InstructionValue<'_>, fallback: u8) -> u8 {
+    let key = e.val_key_instr(instr);
     if let Some(&alloc_reg) = e.regalloc.val_to_reg.get(&key) {
         alloc_reg
     } else {
@@ -1190,7 +1233,7 @@ pub fn result_reg_or(e: &PvmEmitter<'_>, instr: InstructionValue<'_>, fallback: 
 /// Get the allocated register for a value if it's currently valid, otherwise return fallback.
 /// Used for load-side coalescing: callers can use the allocated register directly as an
 /// instruction operand instead of copying to a temp register via `load_operand`.
-pub fn operand_reg(e: &PvmEmitter<'_>, val: BasicValueEnum<'_>, fallback: u8) -> u8 {
+pub fn operand_reg(e: &mut PvmEmitter<'_>, val: BasicValueEnum<'_>, fallback: u8) -> u8 {
     operand_reg_avoiding(e, val, fallback, &[])
 }
 
@@ -1211,7 +1254,7 @@ pub fn operand_reg(e: &PvmEmitter<'_>, val: BasicValueEnum<'_>, fallback: u8) ->
 ///
 /// Single-operand callers (no sibling load) can use [`operand_reg`] directly.
 pub fn operand_reg_avoiding(
-    e: &PvmEmitter<'_>,
+    e: &mut PvmEmitter<'_>,
     val: BasicValueEnum<'_>,
     fallback: u8,
     avoid: &[u8],
@@ -1224,7 +1267,7 @@ pub fn operand_reg_avoiding(
         if iv.is_poison() || iv.is_undef() {
             return fallback;
         }
-        let key = val_key_int(iv);
+        let key = e.val_key_int(iv);
         if let Some(slot) = e.get_slot(key) {
             // Narrow path: value's allocated register currently holds the slot.
             if let Some(&alloc_reg) = e.regalloc.val_to_reg.get(&key)
@@ -1507,7 +1550,7 @@ pub fn pre_scan_function<'ctx>(
 
     // Allocate slots for function parameters.
     for param in function.get_params() {
-        let key = val_key_basic(param);
+        let key = emitter.val_key_basic(param);
         emitter.alloc_slot_for_key(key);
     }
 
@@ -1521,7 +1564,7 @@ pub fn pre_scan_function<'ctx>(
     for bb in function.get_basic_blocks() {
         for instr in bb.get_instructions() {
             if instruction_produces_value(instr) {
-                let key = val_key_instr(instr);
+                let key = emitter.val_key_instr(instr);
                 emitter.alloc_slot_for_key(key);
             }
         }

--- a/crates/wasm-pvm/src/llvm_backend/intrinsics.rs
+++ b/crates/wasm-pvm/src/llvm_backend/intrinsics.rs
@@ -19,7 +19,6 @@ use crate::pvm::Instruction;
 use super::emitter::{
     LoweringContext, PvmEmitter, get_operand, operand_bit_width, operand_reg, operand_reg_avoiding,
     prepare_operand, prepare_operand_avoiding, result_reg, result_slot, try_get_constant,
-    val_key_basic,
 };
 use super::memory::{
     PvmLoadKind, PvmStoreKind, emit_pvm_data_drop, emit_pvm_load, emit_pvm_memory_copy,
@@ -513,7 +512,7 @@ pub fn lower_llvm_intrinsic<'ctx>(
         let is_32 = bits == 32;
 
         // Rotation detection: when a and b are the same SSA value, use RotL/RotR.
-        if val_key_basic(a) == val_key_basic(b) {
+        if e.val_key_basic(a) == e.val_key_basic(b) {
             let dst = result_reg(e, instr);
             // `amt_reg` is resolved lazily below (only on the variable-amount
             // path), so `a_reg` only needs to avoid TEMP2 — the future load

--- a/crates/wasm-pvm/src/llvm_backend/mod.rs
+++ b/crates/wasm-pvm/src/llvm_backend/mod.rs
@@ -41,7 +41,7 @@ use crate::pvm::Instruction;
 use crate::{Error, Result, abi};
 
 use abi::{TEMP_RESULT, TEMP1, TEMP2};
-use emitter::{PvmEmitter, SCRATCH1, SCRATCH2, pre_scan_function, val_key_instr};
+use emitter::{PvmEmitter, SCRATCH1, SCRATCH2, pre_scan_function};
 
 /// Lower a single LLVM function to PVM bytecode.
 ///
@@ -112,6 +112,7 @@ fn lower_function_inner(
             ctx.optimizations.allocate_scratch_regs && emitter::scratch_regs_safe(function);
         emitter.regalloc = regalloc::run(
             function,
+            &mut emitter.val_key_cache,
             &emitter.value_slots,
             is_leaf,
             function.count_params() as usize,
@@ -520,7 +521,7 @@ fn restore_phi_alloc_reg_slots(e: &mut PvmEmitter<'_>, bb: BasicBlock<'_>) {
         if instr.get_opcode() != InstructionOpcode::Phi {
             break;
         }
-        let phi_key = val_key_instr(instr);
+        let phi_key = e.val_key_instr(instr);
         if let Some(&phi_reg) = e.regalloc.val_to_reg.get(&phi_key)
             && let Some(phi_slot) = e.get_slot(phi_key)
         {
@@ -598,7 +599,7 @@ fn emit_prologue<'ctx>(
     // Copy parameters to their SSA slots.
     let params = function.get_params();
     for (i, param) in params.iter().enumerate() {
-        let key = emitter::val_key_basic(*param);
+        let key = e.val_key_basic(*param);
         let slot = e
             .get_slot(key)
             .ok_or_else(|| Error::Internal(format!("no slot for parameter {i} (key {key:?})")))?;

--- a/crates/wasm-pvm/src/llvm_backend/regalloc.rs
+++ b/crates/wasm-pvm/src/llvm_backend/regalloc.rs
@@ -32,7 +32,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use inkwell::values::{FunctionValue, PhiValue};
 
-use super::emitter::{ValKey, is_real_call, val_key_basic, val_key_instr};
+use super::emitter::{ValKey, ValKeyCache, is_real_call, val_key_basic, val_key_instr};
 use super::successors::collect_successors;
 
 /// Base registers always available for allocation (empty — all allocatable
@@ -121,6 +121,7 @@ pub struct RegAllocStats {
 #[allow(clippy::fn_params_excessive_bools, clippy::too_many_arguments)]
 pub fn run<'ctx>(
     function: FunctionValue<'ctx>,
+    val_key_cache: &mut ValKeyCache,
     value_slots: &BTreeMap<ValKey, i32>,
     is_leaf: bool,
     num_params: usize,
@@ -154,7 +155,7 @@ pub fn run<'ctx>(
     }
 
     // Phase 1: Linearize instructions and compute block index ranges.
-    let (instr_index, block_ranges) = linearize(&blocks);
+    let (instr_index, block_ranges) = linearize(val_key_cache, &blocks);
     let max_call_args = max_call_args(function);
     stats.max_call_args = max_call_args;
 
@@ -167,7 +168,7 @@ pub fn run<'ctx>(
     let loop_depths = compute_loop_depths(&block_ranges, &loop_headers, max_position);
 
     // Phase 1d: Collect real call positions for spill weight refinement.
-    let call_positions = collect_call_positions(&blocks, &instr_index);
+    let call_positions = collect_call_positions(val_key_cache, &blocks, &instr_index);
 
     // Phase 2: Compute live intervals + detect loops.
     let min_uses = if aggressive {
@@ -176,6 +177,7 @@ pub fn run<'ctx>(
         MIN_USES_FOR_ALLOCATION
     };
     let (mut intervals, has_loops) = compute_live_intervals(
+        val_key_cache,
         &blocks,
         &instr_index,
         &block_ranges,
@@ -311,6 +313,7 @@ pub fn run<'ctx>(
 /// Maps each LLVM instruction to a linearized index.
 /// Also returns the (start, end) index range for each basic block.
 fn linearize<'ctx>(
+    val_key_cache: &mut ValKeyCache,
     blocks: &[inkwell::basic_block::BasicBlock<'ctx>],
 ) -> (
     BTreeMap<ValKey, usize>,
@@ -323,7 +326,7 @@ fn linearize<'ctx>(
     for &bb in blocks {
         let start = idx;
         for instr in bb.get_instructions() {
-            let key = val_key_instr(instr);
+            let key = val_key_instr(val_key_cache, instr);
             instr_index.insert(key, idx);
             idx += 1;
         }
@@ -435,6 +438,7 @@ fn compute_loop_depths<'ctx>(
 /// Collect linearized positions of real call instructions (sorted ascending).
 /// Used for spill weight refinement: values spanning many calls are penalized.
 fn collect_call_positions(
+    val_key_cache: &mut ValKeyCache,
     blocks: &[inkwell::basic_block::BasicBlock<'_>],
     instr_index: &BTreeMap<ValKey, usize>,
 ) -> Vec<usize> {
@@ -443,7 +447,7 @@ fn collect_call_positions(
         for instr in bb.get_instructions() {
             if instr.get_opcode() == inkwell::values::InstructionOpcode::Call && is_real_call(instr)
             {
-                let key = val_key_instr(instr);
+                let key = val_key_instr(val_key_cache, instr);
                 if let Some(&idx) = instr_index.get(&key) {
                     positions.push(idx);
                 }
@@ -467,6 +471,7 @@ fn count_spanning_calls(call_positions: &[usize], start: usize, end: usize) -> u
 /// Also returns whether any loops were detected (back-edges exist).
 #[allow(clippy::too_many_arguments)]
 fn compute_live_intervals<'ctx>(
+    val_key_cache: &mut ValKeyCache,
     blocks: &[inkwell::basic_block::BasicBlock<'ctx>],
     instr_index: &BTreeMap<ValKey, usize>,
     block_ranges: &HashMap<inkwell::basic_block::BasicBlock<'ctx>, (usize, usize)>,
@@ -494,7 +499,7 @@ fn compute_live_intervals<'ctx>(
     for &bb in blocks {
         let at_loop_header = loop_headers.iter().any(|(h, _)| *h == bb);
         for instr in bb.get_instructions() {
-            let instr_key = val_key_instr(instr);
+            let instr_key = val_key_instr(val_key_cache, instr);
             let instr_idx = instr_index[&instr_key];
 
             // This instruction defines instr_key (if it produces a value).
@@ -520,7 +525,7 @@ fn compute_live_intervals<'ctx>(
                         let num_incomings = phi.count_incoming();
                         for i in 0..num_incomings {
                             if let Some((val, pred_bb)) = phi.get_incoming(i) {
-                                let vk = val_key_basic(val);
+                                let vk = val_key_basic(val_key_cache, val);
                                 if value_slots.contains_key(&vk) {
                                     let (_, pred_end) = block_ranges[&pred_bb];
                                     update_use(
@@ -539,7 +544,7 @@ fn compute_live_intervals<'ctx>(
                 _ => {
                     for i in 0..num_ops {
                         if let Some(inkwell::values::Operand::Value(val)) = instr.get_operand(i) {
-                            let vk = val_key_basic(val);
+                            let vk = val_key_basic(val_key_cache, val);
                             if value_slots.contains_key(&vk) {
                                 update_use(
                                     &mut last_use,
@@ -562,16 +567,11 @@ fn compute_live_intervals<'ctx>(
         def_point.entry(vk).or_insert(0);
     }
 
-    // Build intervals, extending for loops. We iterate by slot offset (not
-    // by ValKey) because ValKey wraps the raw LLVM value pointer — pointer
-    // order within a BTreeMap varies across process invocations (ASLR, and
-    // LLVM arenas for different Value subclasses sit at independent base
-    // addresses). Slot offsets are assigned by a bump allocator in insertion
-    // order and are stable across runs.
-    let mut by_slot: Vec<(ValKey, i32)> = value_slots.iter().map(|(&k, &v)| (k, v)).collect();
-    by_slot.sort_by_key(|(_, slot)| *slot);
+    // Build intervals, extending for loops. `ValKey` is an insertion-order ID
+    // (see `ValKeyCache`), so iterating `value_slots` by key order is itself
+    // reproducible across runs.
     let mut intervals = Vec::new();
-    for (vk, slot) in by_slot {
+    for (&vk, &slot) in value_slots {
         let start = def_point.get(&vk).copied().unwrap_or(0);
         let mut end = last_use.get(&vk).copied().unwrap_or(start);
         let uses = use_count.get(&vk).copied().unwrap_or(0);

--- a/docs/src/learnings.md
+++ b/docs/src/learnings.md
@@ -609,13 +609,13 @@ The compiler must produce byte-identical JAM output for the same WASM input acro
 
 Rust's default `HashMap`/`HashSet` use a per-process-randomised hasher, so iteration order changes between CLI invocations. Any iteration whose side effects reach the emitted bytes (emitting an instruction, assigning a register/offset, mutating state read by the next iteration) leaks that randomness. The mitigation is the `AGENTS.md` rule: prefer `BTreeMap`/`BTreeSet` throughout; if a key type has no `Ord` (e.g. `inkwell::BasicBlock`), keep the `HashMap` for lookups only and collect into a `Vec` sorted by a derived key before iterating.
 
-### Trap 2: `BTreeMap<ValKey, _>` is *not* reproducible across runs
+### Trap 2: `ValKey` originally wrapped a raw LLVM pointer
 
-This one is non-obvious. `ValKey` wraps `Value::as_value_ref() as usize` — the raw LLVM pointer. LLVM allocates different `Value` subclasses (e.g. `Argument`, `InstructionValue`) from separate arenas, and those arenas sit at independent ASLR-randomised base addresses. So `BTreeMap<ValKey, _>` iteration is pointer-address order, which can flip between invocations whenever entries come from different arenas. A same-process loop over a `BTreeMap<ValKey, _>` is stable; a diff between two process runs is not.
+`ValKey` used to wrap `Value::as_value_ref() as usize` — the raw LLVM pointer. LLVM allocates different `Value` subclasses (e.g. `Argument`, `InstructionValue`) from separate arenas at independent ASLR-randomised base addresses, so the derived `Ord` was pointer-address order: a `BTreeMap<ValKey, _>` iterated in pointer order, which flipped between process invocations whenever entries came from different arenas.
 
-Where this actually bit us: `compute_live_intervals` iterated `value_slots: BTreeMap<ValKey, i32>` directly and then pushed intervals into a `Vec` in that order. The downstream linear scan is stable-sorted by `(start, spill_weight)`; ties fall back to input order, which meant pointer order, which meant non-deterministic register assignments under aggressive allocation (more ties at min_uses=1).
+Where this bit us: `compute_live_intervals` iterated `value_slots: BTreeMap<ValKey, i32>` directly and then pushed intervals into a `Vec` in that order. The downstream linear scan is stable-sorted by `(start, spill_weight)`; ties fell back to input order, which meant pointer order, which meant non-deterministic register assignments under aggressive allocation (more ties at min_uses=1).
 
-The fix is to iterate by a derived in-process-stable key. `value_slots` values are bump-allocated slot offsets (monotonic in insertion order), so sorting by slot offset gives insertion order. `instr_index` maps `ValKey → linearised position` for the same purpose when values come from instructions. The `ValKey` doc comment carries a warning; heed it.
+The fix (issue #204) replaces the raw pointer with an insertion-order ID. A per-function `ValKeyCache` on `PvmEmitter` maps the LLVM pointer to a monotonically-increasing `u32` the first time the value is observed during IR walking; subsequent observations return the same ID. Because the IR-walking order (`pre_scan_function` + regalloc linearisation) is deterministic, the IDs are too — `BTreeMap<ValKey, _>` iteration is now reproducible across runs by construction, no derived-key sort required.
 
 ### Trap 3: Order-dependent loops over `HashMap<BasicBlock, _>`
 


### PR DESCRIPTION
## Summary

- `ValKey` no longer wraps the raw LLVM value pointer. A new `ValKeyCache` on `PvmEmitter` maps the pointer to a per-function insertion-order `u32` ID the first time the value is observed during IR walking. The derived `Ord` on `ValKey` is now safe and reproducible across runs by construction — no ASLR/arena-address dependency.
- Drops the `sort_by_key(slot)` workaround in `compute_live_intervals` (introduced as a band-aid in #203). `value_slots` is iterated directly.
- The three `val_key_*` helpers take `&mut ValKeyCache`; convenience methods on `PvmEmitter` forward to it. The five `&PvmEmitter` emit-phase helpers (`result_slot`, `result_reg`, `result_reg_or`, `operand_reg`, `operand_reg_avoiding`, plus `get_valid_alloc_reg` in `control_flow.rs`) now take `&mut PvmEmitter`. Regalloc threads the cache through `run` → `linearize` → `collect_call_positions` → `compute_live_intervals`.
- Updates `ValKey`'s doc comment and the `docs/src/learnings.md` "Trap 2" section to describe the new insertion-order design.

Closes #204.

## Test plan

- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --release` — all unit tests pass
- [x] `bun run test` (layer 1–3 integration tests) — 670 pass / 0 fail
- [x] `./tests/utils/check-determinism.sh` — 17/17 fixtures byte-identical across 10 runs
- [x] **JAM-byte-identical to `main`**: SHA-256 hashes match across all 17 determinism-check fixtures

## Benchmark results

`./tests/utils/benchmark.sh --base 1fb8643 --current td-issue-204` (commit hash for main because `main` is checked out in another worktree).

### Direct execution

| Benchmark | JAM Size (before) | JAM Size (after) | Size Change | Code (before) | Code (after) | Code Change | Gas (before) | Gas (after) | Gas Change |
|-----------|--------------|-------------|-------------|--------------|-------------|-------------|-------------|------------|------------|
| add(5,7)             |          160 |          160 |     +0 (+0.0%) |           96 |           96 |     +0 (+0.0%) |         27 |         27 |     +0 (+0.0%) |
| fib(20)              |          221 |          221 |     +0 (+0.0%) |          144 |          144 |     +0 (+0.0%) |        429 |        429 |     +0 (+0.0%) |
| factorial(10)        |          200 |          200 |     +0 (+0.0%) |          126 |          126 |     +0 (+0.0%) |        185 |        185 |     +0 (+0.0%) |
| is_prime(25)         |          271 |          271 |     +0 (+0.0%) |          189 |          189 |     +0 (+0.0%) |         61 |         61 |     +0 (+0.0%) |
| AS fib(10)           |          613 |          613 |     +0 (+0.0%) |          488 |          488 |     +0 (+0.0%) |        256 |        256 |     +0 (+0.0%) |
| AS factorial(7)      |          603 |          603 |     +0 (+0.0%) |          479 |          479 |     +0 (+0.0%) |        221 |        221 |     +0 (+0.0%) |
| AS gcd(2017,200)     |          609 |          609 |     +0 (+0.0%) |          489 |          489 |     +0 (+0.0%) |        163 |        163 |     +0 (+0.0%) |
| AS decoder           |         6523 |         6523 |     +0 (+0.0%) |         4692 |         4692 |     +0 (+0.0%) |        912 |        912 |     +0 (+0.0%) |
| AS array             |         5923 |         5923 |     +0 (+0.0%) |         4171 |         4171 |     +0 (+0.0%) |        779 |        779 |     +0 (+0.0%) |
| regalloc two loops(500) |          561 |          561 |     +0 (+0.0%) |          438 |          438 |     +0 (+0.0%) |      34073 |      34073 |     +0 (+0.0%) |
| aslan-fib accumulate |        19831 |        19831 |     +0 (+0.0%) |        12186 |        12186 |     +0 (+0.0%) |      10431 |      10431 |     +0 (+0.0%) |
| host-call-log        |          458 |          458 |     +0 (+0.0%) |          104 |          104 |     +0 (+0.0%) |         40 |         40 |     +0 (+0.0%) |
| anan-as PVM interpreter |       109288 |       109288 |     +0 (+0.0%) |        76243 |        76243 |     +0 (+0.0%) |          - |          - |              - |
| aslan-ecalli accumulate |        42350 |        42350 |     +0 (+0.0%) |        27349 |        27349 |     +0 (+0.0%) |  100000000 |  100000000 |     +0 (+0.0%) |
| blake2b("abc",32)    |         3765 |         3765 |     +0 (+0.0%) |         2486 |         2486 |     +0 (+0.0%) |      14819 |      14819 |     +0 (+0.0%) |
| sha512("abc")        |         3511 |         3511 |     +0 (+0.0%) |         2310 |         2310 |     +0 (+0.0%) |      14459 |      14459 |     +0 (+0.0%) |
| u128 mul x1000       |          457 |          457 |     +0 (+0.0%) |          342 |          342 |     +0 (+0.0%) |      71031 |      71031 |     +0 (+0.0%) |
| u128 div(fast) x1000 |          765 |          765 |     +0 (+0.0%) |          606 |          606 |     +0 (+0.0%) |      68031 |      68031 |     +0 (+0.0%) |
| u128 div(slow) x1000 |          771 |          771 |     +0 (+0.0%) |          607 |          607 |     +0 (+0.0%) |     129031 |     129031 |     +0 (+0.0%) |
| sha512(240x"a" — multi-block + two-pad) |         3511 |         3511 |     +0 (+0.0%) |         2310 |         2310 |     +0 (+0.0%) |      43111 |      43111 |     +0 (+0.0%) |

### PVM-in-PVM

| Benchmark | JAM Size (before) | JAM Size (after) | Size Change | Code (before) | Code (after) | Code Change | Gas (before) | Gas (after) | Gas Change |
|-----------|--------------|-------------|-------------|--------------|-------------|-------------|-------------|------------|------------|
| PiP TRAP             |           21 |           21 |     +0 (+0.0%) |            1 |            1 |     +0 (+0.0%) |      79924 |      79924 |     +0 (+0.0%) |
| PiP add(5,7)         |          160 |          160 |     +0 (+0.0%) |           96 |           96 |     +0 (+0.0%) |    1128926 |    1128926 |     +0 (+0.0%) |
| PiP host-call-log    |          458 |          458 |     +0 (+0.0%) |          104 |          104 |     +0 (+0.0%) |    1172874 |    1172874 |     +0 (+0.0%) |
| PiP AS fib(10)       |          613 |          613 |     +0 (+0.0%) |          488 |          488 |     +0 (+0.0%) |    1475633 |    1475633 |     +0 (+0.0%) |
| PiP JAM-SDK fib(10)  |        25965 |        25965 |     +0 (+0.0%) |        16623 |        16623 |     +0 (+0.0%) |    8292277 |    8292277 |     +0 (+0.0%) |
| PiP Jambrains fib(10) |        62591 |        62591 |     +0 (+0.0%) |            - |            - |              - |    7379669 |    7379669 |     +0 (+0.0%) |
| PiP JADE fib(10)     |        68947 |        68947 |     +0 (+0.0%) |        46773 |        46773 |     +0 (+0.0%) |   17872808 |   17872808 |     +0 (+0.0%) |
| PiP aslan-fib accumulate |        19831 |        19831 |     +0 (+0.0%) |        12186 |        12186 |     +0 (+0.0%) |   12912382 |   12912382 |     +0 (+0.0%) |
| PiP blake2b("abc",32) |         3765 |         3765 |     +0 (+0.0%) |         2486 |         2486 |     +0 (+0.0%) |   12616854 |   12616854 |     +0 (+0.0%) |
| PiP sha512("abc")    |         3511 |         3511 |     +0 (+0.0%) |         2310 |         2310 |     +0 (+0.0%) |   12326827 |   12326827 |     +0 (+0.0%) |
| PiP sha512(240x"a")  |         3511 |         3511 |     +0 (+0.0%) |         2310 |         2310 |     +0 (+0.0%) |   32970464 |   32970464 |     +0 (+0.0%) |

Pure refactor — every size and gas metric is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)