### PR TITLE
fix(backend): preserve alloc state across div-by-zero trap-bypass labels

### DIFF
--- a/crates/wasm-pvm/src/llvm_backend/alu.rs
+++ b/crates/wasm-pvm/src/llvm_backend/alu.rs
@@ -48,7 +48,13 @@ fn emit_wasm_div_zero_trap(e: &mut PvmEmitter, rhs_reg: u8) {
     let ok_label = e.alloc_label();
     e.emit_branch_ne_imm_to_label(rhs_reg, 0, ok_label);
     e.emit(Instruction::Trap);
-    e.define_label(ok_label);
+    // Intra-block trap bypass: the only path into `ok_label` is the branch
+    // above, which does not modify any registers. Use the cache-preserving
+    // variant so that `define_label`'s state clear does not invalidate
+    // `alloc_reg_slot` mappings for values that are live across this check.
+    // Without this, downstream `load_operand` falls back to LoadIndU64 from
+    // a stack slot whose store was elided by lazy spill, reading stale data.
+    e.define_label_preserving_cache(ok_label);
 }
 
 /// Emit a WASM-style trap for signed overflow (`INT_MIN` / -1).
@@ -111,8 +117,11 @@ fn emit_wasm_signed_overflow_trap(e: &mut PvmEmitter, lhs_reg: u8, rhs_reg: u8, 
     // 3. Trap if we are here (rhs == -1 AND lhs == INT_MIN)
     e.emit(Instruction::Trap);
 
-    // 4. Label
-    e.define_label(ok_label);
+    // 4. Label. Intra-block trap bypass: every predecessor of `ok_label` is
+    // one of the branches above, none of which modifies a register. Preserve
+    // the cache so values live across the check (e.g. loop phi destinations
+    // held in allocated registers) remain reachable via the alloc reg map.
+    e.define_label_preserving_cache(ok_label);
 }
 
 /// Build the immediate-form instruction for a commutative binary op (Add, Mul, And, Or, Xor).

--- a/docs/src/learnings.md
+++ b/docs/src/learnings.md
@@ -862,6 +862,20 @@ The cache snapshot taken before lowering a block's terminator (`llvm_backend/mod
 
 Fix: invalidate `TEMP1`, `TEMP2`, `TEMP_RESULT`, `SCRATCH1`, `SCRATCH2` in the snapshot — the full set of registers any terminator path may touch. This is a strict superset of what was invalidated before, so it can never make a successor read a fresher cache entry than is actually valid.
 
+## Intra-Block Trap-Bypass Labels Must Preserve Cache (#256)
+
+The WASM-style trap helpers in `llvm_backend/alu.rs` — `emit_wasm_div_zero_trap` and `emit_wasm_signed_overflow_trap` — emit a one-shot bypass pattern: `BranchNeImm/BranchGeS … → ok_label; Trap; ok_label:`. The label is purely intra-block (its only predecessor is the branch above; the falls-through `Trap` is unreachable), so register state at the label equals state at the branch. Both helpers used to call `define_label(ok_label)`, which under the hood calls `clear_reg_cache` and wipes `alloc_reg_slot` / `alloc_dirty` for every allocated register.
+
+With lazy spill on, that wipe is silently destructive. The back-edge phi copy in `emit_phi_copies_regaware` writes the new phi value into the phi's allocated register (via `emit_raw_move`) and calls `set_alloc_reg_for_slot(phi_reg, phi_slot)` — but it does **not** emit a `StoreIndU64` to the slot (that's the entire point of lazy spill). The phi value lives in the register; the stack slot stays stale. Then on the next iteration, every `load_operand(%phi, …)` is supposed to take the fast path against `alloc_reg_slot[phi_reg] == Some(phi_slot)` and emit `MoveReg` from the alloc reg. If a `define_label` clears `alloc_reg_slot` between two uses of the phi, the second `load_operand` instead emits `LoadIndU64` from the stale slot — and the loop reads garbage.
+
+The aslan-ecalli fixture trips this for the `value` phi in AssemblyScript's `utoa_dec_simple` (`value % 10` then `value / 10` per iteration, with the rem's trap bypass between the two reads). With every other optimization on, the loop reads stack[64] forever and burns ~100M gas. Turning off any of `--lazy-spill`, `--register-alloc`, or `--shrink-wrap` masks the bug (the first two suppress the store elision; the third shifts the regalloc decision so the phi lands elsewhere) — the symptom is a 4-orders-of-magnitude gas swing from flipping unrelated-looking flags.
+
+Fix: both trap helpers now call `define_label_preserving_cache(ok_label)`. That records the label PC and emits a Fallthrough if needed, but does **not** clear any cache state. Safe because the only live edge into the label is the branch above, which doesn't write any registers — so the cache at the label equals the cache before the branch.
+
+This pattern is specific to *single-predecessor intra-block labels where the fall-through path is unreachable*. Other `define_label` callers in `llvm_backend/intrinsics.rs` (the `abs` two-path merge), `llvm_backend/memory.rs` (bulk-memory loop bodies), and `llvm_backend/mod.rs` (block boundaries with cross-block propagation) all have multiple live predecessors and must keep clearing — preservation would let one path's stale alloc state leak into another. The trap-bypass case is uniquely safe.
+
+Don't generalize this by making `define_label` "smart" (e.g. "preserve if the previous instruction is the lone branch to this label"). The emitter doesn't track which `define_label` calls are merge points vs. trap-bypasses, and a peephole-style "only one preceding branch" check would miss labels whose predecessors are also stitched in by `emit_jump_to_label` fixups elsewhere. The call-site distinction is structural and clearer.
+
 ## Global Storage Width: Per-Type Slots, Not Uniform 8-Byte Widening
 
 For most of the compiler's history each WASM global was stored in a fixed 4-byte slot at `0x30000 + (has_mem_size ? 4 : 0) + idx * 4`, and the lowering in `llvm_backend/memory.rs` emitted `LoadU32`/`StoreU32` for every `global.get` / `global.set`. That worked invisibly because:

--- a/tests/fixtures/wat/div-zero-trap-clobber.jam.wat
+++ b/tests/fixtures/wat/div-zero-trap-clobber.jam.wat
@@ -1,0 +1,74 @@
+(module
+  (memory 1)
+
+  ;; Regression test for issue #256.
+  ;;
+  ;; In a do-while loop the carried `value` phi is used TWICE per
+  ;; iteration: once for `value % 10` (sum-of-digits) and again, after
+  ;; that rem_u's div-by-zero trap-bypass label, for `value / 10`. The
+  ;; second read goes through `load_operand`. Before the fix, the
+  ;; trap-bypass `define_label` cleared `alloc_reg_slot`, so the
+  ;; second read fell back to `LoadIndU64` from the phi's stack slot;
+  ;; with lazy-spill on, that slot's back-edge update was elided and
+  ;; the loop read stale data.
+  ;;
+  ;; Mirrors the AssemblyScript `utoa_dec_simple` shape that triggered
+  ;; the aslan-ecalli all-opts OOM. The do-while body forms a single
+  ;; LLVM block (phi at top, conditional back-branch at bottom), so
+  ;; LLVM keeps the phi value in a register across the trap-bypasses
+  ;; instead of re-spilling at a loop-header block boundary. Extra
+  ;; live phis (`ext_a..d`) raise register pressure to push the value
+  ;; phi into a callee-saved register and exercise lazy-spill.
+  (func (export "main") (param $args_ptr i32) (param $args_len i32) (result i64)
+    (local $value i32)
+    (local $sum i32)
+    (local $ext_a i32)
+    (local $ext_b i32)
+    (local $ext_c i32)
+    (local $ext_d i32)
+
+    (local.set $value (i32.load (local.get $args_ptr)))
+    (local.set $sum (i32.const 0))
+    (local.set $ext_a (i32.load offset=4 (local.get $args_ptr)))
+    (local.set $ext_b (i32.load offset=8 (local.get $args_ptr)))
+    (local.set $ext_c (i32.load offset=12 (local.get $args_ptr)))
+    (local.set $ext_d (i32.load offset=16 (local.get $args_ptr)))
+
+    ;; If the input is < 10 we still want one digit; pad sum so the
+    ;; caller's expected output is the digit sum either way. The
+    ;; interesting case is the do-while below.
+    (if (i32.ge_u (local.get $value) (i32.const 10))
+      (then
+        (loop $continue
+          ;; Rotate extras through arithmetic on every iteration and
+          ;; park them to memory so they stay live across the body but
+          ;; do not contaminate the result.
+          (local.set $ext_a (i32.add (local.get $ext_a) (local.get $value)))
+          (local.set $ext_b (i32.xor (local.get $ext_b) (local.get $ext_a)))
+          (local.set $ext_c (i32.add (local.get $ext_c) (local.get $ext_b)))
+          (local.set $ext_d (i32.xor (local.get $ext_d) (local.get $ext_c)))
+          (i32.store (i32.const 64) (local.get $ext_a))
+          (i32.store (i32.const 68) (local.get $ext_b))
+          (i32.store (i32.const 72) (local.get $ext_c))
+          (i32.store (i32.const 76) (local.get $ext_d))
+
+          ;; First use of $value: rem_u — trap-bypass #1.
+          (local.set $sum
+            (i32.add (local.get $sum)
+              (i32.rem_u (local.get $value) (i32.const 10))))
+
+          ;; Second use of $value: div_u — trap-bypass #2. With the
+          ;; pre-fix bug this read falls back to slot[$value], which
+          ;; was never written on the back-edge.
+          (local.set $value (i32.div_u (local.get $value) (i32.const 10)))
+
+          ;; do-while: keep looping while value >= 10.
+          (br_if $continue (i32.ge_u (local.get $value) (i32.const 10)))
+        )
+      )
+    )
+
+    (i32.store (i32.const 0) (local.get $sum))
+    (i64.const 17179869184)  ;; ptr=0, len=4
+  )
+)

--- a/tests/layer3/div-zero-trap-clobber.test.ts
+++ b/tests/layer3/div-zero-trap-clobber.test.ts
@@ -13,11 +13,12 @@ import { defineSuite } from "../helpers/suite";
 // pressure so the compiler keeps `value` in a callee-saved register.
 //
 // args layout (5 i32, little-endian): value, ext_a, ext_b, ext_c, ext_d.
-// Result = digit_sum(value) + ext_a' + ext_b' + ext_c' + ext_d',
-// where the extras are rotated through xor/add per loop iteration.
+// Result = digit_sum(value). The extras are rotated through xor/add per
+// loop iteration and parked to memory but are not part of the returned
+// value (the WAT only stores `$sum` at address 0).
 //
-// For value=12345 and extras = 0: extras stay 0, digit sum = 5+4+3+2 = 14.
-// For value=10 and extras = 0: digit sum = 0 (10%10 = 0).
+// For value=12345: digit sum = 5+4+3+2 = 14.
+// For value=10: digit sum = 0 (10%10 = 0).
 const tests = [
   {
     args: "01000000" + "00000000".repeat(4),

--- a/tests/layer3/div-zero-trap-clobber.test.ts
+++ b/tests/layer3/div-zero-trap-clobber.test.ts
@@ -1,0 +1,54 @@
+import { defineSuite } from "../helpers/suite";
+
+// Regression test for issue #256: the div-by-zero trap-bypass label
+// (used by i32.div_u/rem_u) used to call `define_label`, which clears
+// the emitter's `alloc_reg_slot` state. With lazy spill on, the
+// loop-carried `value` phi was held in an allocated register; the
+// back-edge spill was elided, so when the cleared alloc state forced a
+// reload from the (never-written) stack slot, the loop read garbage
+// and either spun forever or returned a wrong sum.
+//
+// The fixture uses `value` TWICE per iteration around two trap
+// bypasses (rem_u then div_u), plus extra live phis to raise register
+// pressure so the compiler keeps `value` in a callee-saved register.
+//
+// args layout (5 i32, little-endian): value, ext_a, ext_b, ext_c, ext_d.
+// Result = digit_sum(value) + ext_a' + ext_b' + ext_c' + ext_d',
+// where the extras are rotated through xor/add per loop iteration.
+//
+// For value=12345 and extras = 0: extras stay 0, digit sum = 5+4+3+2 = 14.
+// For value=10 and extras = 0: digit sum = 0 (10%10 = 0).
+const tests = [
+  {
+    args: "01000000" + "00000000".repeat(4),
+    expected: 0,
+    description: "value=1: loop never runs, sum=0",
+  },
+  {
+    args: "09000000" + "00000000".repeat(4),
+    expected: 0,
+    description: "value=9: boundary, sum=0",
+  },
+  {
+    args: "0a000000" + "00000000".repeat(4),
+    expected: 0,
+    description: "value=10: one iter; 10%10=0",
+  },
+  {
+    args: "39300000" + "00000000".repeat(4),
+    expected: 14,
+    description: "value=12345: 5+4+3+2=14",
+  },
+  // value=4294967295 → digits 4,2,9,4,9,6,7,2,9,5; loop visits the bottom 9
+  // (4 < 10 exits) and sums 5+9+2+7+6+9+4+9+2 = 53.
+  {
+    args: "ffffffff" + "00000000".repeat(4),
+    expected: 53,
+    description: "value=u32::MAX: bottom 9 digits sum",
+  },
+];
+
+defineSuite({
+  name: "div-zero-trap-clobber",
+  tests: tests,
+});


### PR DESCRIPTION
Closes #256.

## Summary

- `emit_wasm_div_zero_trap` and `emit_wasm_signed_overflow_trap` in `llvm_backend/alu.rs` now use `define_label_preserving_cache` for the trap-bypass `ok_label`. The trap-bypass is intra-block — the only live edge into the label is the branch above, and the fall-through `Trap` is unreachable — so register state at the label equals state at the branch and clearing the cache is unnecessary.
- Without this, the standard `define_label` wipes `alloc_reg_slot` for every allocated register. With lazy-spill on, the back-edge phi copy writes the new phi value into the allocated register but elides the `StoreIndU64` to the slot (that's lazy-spill's whole point). When `alloc_reg_slot` is cleared between two uses of the same phi inside the block, the second `load_operand` falls back to `LoadIndU64` from a slot whose store was elided — reading stale data.
- This is the root cause of the `aslan-ecalli` OOM under all-opts-on baseline. AssemblyScript's `utoa_dec_simple` uses `value % 10` and `value / 10` per iteration with the `rem`'s trap-bypass between them; the second read loops on stale `stack[64]` and burns ~100 M gas. Turning off any of `--lazy-spill`, `--register-alloc`, or `--shrink-wrap` masked the symptom (the first two suppress the store elision; the third shifts the regalloc decision so the phi lands elsewhere).
- Other `define_label` callers (`memory.rs` bulk-memory bounds checks, `calls.rs` sig check, `intrinsics.rs` abs merge, `mod.rs` block boundaries) either operate only on scratch regs or are real merge points where the clear is correct.

## Benchmark (vs origin/main @ `6659349`)

### Direct execution

| Benchmark | JAM Δ | Code Δ | Gas Δ |
|---|---|---|---|
| add(5,7) | 0 | 0 | 0 |
| fib(20) | 0 | 0 | 0 |
| factorial(10) | 0 | 0 | 0 |
| is_prime(25) | −9 | −8 | −3 |
| AS fib(10) | 0 | 0 | 0 |
| AS factorial(7) | 0 | 0 | 0 |
| AS gcd(2017,200) | 0 | 0 | 0 |
| AS decoder | 0 | 0 | 0 |
| AS array | 0 | 0 | 0 |
| regalloc two loops(500) | 0 | 0 | 0 |
| aslan-fib accumulate | −31 | −27 | −3 |
| host-call-log | 0 | 0 | 0 |
| anan-as PVM interpreter | −29 | −26 | n/a |
| **aslan-ecalli accumulate** | **−7** | **−6** | **−99 993 536** |
| blake2b("abc",32) | 0 | 0 | 0 |
| sha512("abc") | 0 | 0 | 0 |
| u128 mul x1000 | 0 | 0 | 0 |
| u128 div(fast) x1000 | 0 | 0 | 0 |
| u128 div(slow) x1000 | 0 | 0 | 0 |
| sha512(240×"a") | 0 | 0 | 0 |

### PVM-in-PVM (outer gas)

| Benchmark | Outer Gas Δ |
|---|---|
| PiP TRAP | 0 |
| PiP add(5,7) | 0 |
| PiP host-call-log | 0 |
| PiP AS fib(10) | 0 |
| PiP JAM-SDK fib(10) | 0 |
| PiP Jambrains fib(10) | −9 |
| PiP JADE fib(10) | 0 |
| PiP aslan-fib accumulate | −11 434 |
| PiP blake2b("abc",32) | 0 |
| PiP sha512("abc") | 0 |
| PiP sha512(240×"a") | 0 |

- **aslan-ecalli**: gas drops from the 100 M OOM ceiling to 6 464 — four orders of magnitude. JAM shrinks 7 B because the second `value` read becomes `MoveReg` instead of `LoadIndU64`.
- 4 fixtures see small wins (8-31 B + a few gas) because they also have div/rem inside loops whose phi value is read after the trap-bypass: `is_prime(25)`, `aslan-fib accumulate`, `anan-as PVM interpreter`, and `aslan-ecalli`. PiP `aslan-fib` improves ~0.09 % outer gas.
- 16 fixtures byte-identical against main — the fix is non-perturbative for code paths that don't depend on cross-trap-bypass alloc state.

## Test plan

- [x] `cargo test --release` (36 unit + 1 doc)
- [x] `cd tests && bun run test` (675 / layer 1-3 — incl. 5 new cases in `tests/layer3/div-zero-trap-clobber.test.ts`)
- [x] `bun test layer4/ layer5/ --test-name-pattern "pvm-in-pvm"` (277)
- [x] `bun run test:differential` (142)
- [x] Manual: `node vendor/anan-as/dist/bin/index.js run --spi --no-logs --gas=200000000 --pc=0 tests/build/jam/aslan-ecalli.jam 0x00` halts cleanly with 6 464 gas used (was OOM at PC 8796)
- [x] Verified `tests/layer3/div-zero-trap-clobber.test.ts` (u32::MAX, 12345 cases) fails on main and passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)